### PR TITLE
fix: installed bin entrypoint

### DIFF
--- a/.changeset/fix-installed-bin.md
+++ b/.changeset/fix-installed-bin.md
@@ -1,0 +1,5 @@
+---
+"@shopify/ucp-cli": patch
+---
+
+Fix the installed package bin so package-manager symlinks run the CLI instead of exiting 0 with no output.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Symlink globally for active dev:
 
 ```sh
 pnpm build && pnpm link --global
-# Now `ucp` everywhere points at this repo's dist/cli.js. Re-run pnpm build
+# Now `ucp` everywhere points at this repo's dist/bin.js. Re-run pnpm build
 # after changes; the symlink stays valid.
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "bin": {
-    "ucp": "./dist/cli.js"
+    "ucp": "./dist/bin.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,6 @@
+import { runUcpCli } from './cli.js'
+
+// Keep the package executable as a tiny unconditional entrypoint. The CLI
+// factory lives in cli.ts for tests/imports; this module is only reached through
+// package.json#bin, so it must not use an import.meta/process.argv[1] guard.
+await runUcpCli()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,8 +5,6 @@
 // --help, --llms, --mcp, `mcp add`, and `skills`. Integration tests should
 // exercise this dispatcher directly so output shape stays faithful.
 
-import { fileURLToPath } from 'node:url'
-
 import { Cli, middleware, z } from 'incur'
 
 import { buildCta } from './cli/cta.js'
@@ -1149,13 +1147,12 @@ export function isSkillsAddInvocation(argv: readonly string[]): boolean {
   )
 }
 
-// Binary entrypoint stays at the bottom of the module. See note (2) on
-// businessNotResolvedError above for the ESM-ordering rationale.
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+export async function runUcpCli(argv = process.argv.slice(2)): Promise<void> {
   // `--mcp` toggles MCP stdio mode in incur. The escalation hook must be a
-  // no-op in that mode (see src/core/escalation.ts). Detecting at the entry
-  // and threading via `inMcpMode` keeps the run-handler boundary clean.
-  const inMcpMode = process.argv.includes('--mcp')
+  // no-op in that mode (see src/core/escalation.ts). Detecting at the executable
+  // boundary and threading via `inMcpMode` keeps run handlers importable and
+  // side-effect free for tests/library consumers.
+  const inMcpMode = argv.includes('--mcp')
   // `--verbose` flips on stderr trace output (see src/core/verbose.ts). Muted
   // in MCP mode — stderr during stdio JSON-RPC has no human reader and would
   // confuse log scrapers attached to the host. Two reasons we detect from
@@ -1171,7 +1168,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // listed in `ucp --help` Global Options — incur 0.4.5 hard-codes that
   // block (Help.js:262) with no extension hook. Documented in README under
   // Development → Debug tracing until upstream exposes a registration API.
-  const argv = process.argv.slice(2)
   const verboseRequested =
     argv.includes('--verbose') ||
     process.env.UCP_VERBOSE === '1' ||

--- a/test/integration/catalog-live.integration.test.ts
+++ b/test/integration/catalog-live.integration.test.ts
@@ -32,7 +32,7 @@ import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
 
 const execFileAsync = promisify(execFile)
-const CLI_PATH = fileURLToPath(new URL('../../dist/cli.js', import.meta.url))
+const CLI_PATH = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
 
 const LIVE = process.env.UCP_LIVE_TESTS === '1' || process.env.UCP_LIVE_TESTS === 'true'
 

--- a/test/integration/purchase-journey.integration.test.ts
+++ b/test/integration/purchase-journey.integration.test.ts
@@ -12,7 +12,7 @@
 // without external help? The assertions model what a competent agent
 // would check at each step.
 //
-// Runs against dist/cli.js — `pnpm test:integration` builds first.
+// Runs against the packaged bin entry — `pnpm test:integration` builds first.
 
 import { execFile } from 'node:child_process'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
@@ -31,7 +31,7 @@ import {
 } from '../fixtures/mock-ucp-shopping.js'
 
 const execFileAsync = promisify(execFile)
-const CLI = fileURLToPath(new URL('../../dist/cli.js', import.meta.url))
+const CLI = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
 
 interface Journey {
   businessUrl: string

--- a/test/integration/smoke.integration.test.ts
+++ b/test/integration/smoke.integration.test.ts
@@ -3,12 +3,12 @@
 // incur's serve() behavior matches what PROTOCOL expects (exit codes,
 // --version, --llms, help on no args).
 //
-// Runs against dist/cli.js (must `pnpm build` first; pnpm test:integration
-// does so for you).
+// Runs against the packaged bin entry (must `pnpm build` first; pnpm
+// test:integration does so for you).
 
 import { execFile, spawn } from 'node:child_process'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { platform, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 import { startMockBusiness } from '../fixtures/mock-business.js'
 
 const execFileAsync = promisify(execFile)
-const CLI_PATH = fileURLToPath(new URL('../../dist/cli.js', import.meta.url))
+const CLI_PATH = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
 
 async function run(...args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
   try {
@@ -34,6 +34,19 @@ describe('smoke: compiled binary', () => {
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
     expect(code).toBe(0)
   })
+
+  it.skipIf(platform() === 'win32')(
+    'serves when invoked through an installed-bin symlink',
+    async () => {
+      const binDir = await mkdtemp(join(tmpdir(), 'ucp-bin-symlink-'))
+      const binPath = join(binDir, 'ucp')
+      await symlink(CLI_PATH, binPath)
+
+      const { stdout, stderr } = await execFileAsync('node', [binPath, '--version'])
+      expect(stderr).toBe('')
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
+    },
+  )
 
   it('bare invocation prints help with the cli name + description, exits 0', async () => {
     const { stdout, code } = await run()

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { buildDefines } from './scripts/defines.mjs'
 
 export default defineConfig({
   entry: {
-    cli: 'src/cli.ts',
+    bin: 'src/bin.ts',
     index: 'src/index.ts',
   },
   format: ['esm'],


### PR DESCRIPTION
Report: https://x.com/SammyIsseyegh/status/2056439749682864226

The published 0.4.2 package installed successfully but the `ucp` bin could exit 0 with no output when invoked through the package-manager symlink. The old entrypoint lived behind a process.argv/import.meta direct-invocation guard, so symlinked installs could import the module without ever calling incur.

Fix: Split the executable boundary from the importable CLI module: `src/bin.ts` always runs `runUcpCli()`, while `src/cli.ts` remains side-effect free for tests and library imports. Point package.json#bin and integration tests at`dist/bin.js` so CI exercises the same artifact users install.