### PR TITLE
refactor/simplify escalation hooks

### DIFF
--- a/.changeset/drop-file-hook-source.md
+++ b/.changeset/drop-file-hook-source.md
@@ -1,0 +1,17 @@
+---
+"@shopify/ucp-cli": minor
+---
+
+Drop the `~/.ucp/hooks/escalation` file-source for escalation hooks. The escalation hook contract is now three sources — `--on-escalation` flag, `UCP_ON_ESCALATION` env, `~/.ucp/config.yaml` `escalation.command` — all shell command strings, identical on every OS.
+
+The file convention duplicated config-source ("put your command in a file" vs "point config at a file"), had no meaningful `X_OK` semantics on Windows, and forced platform asymmetry users had to learn around. To run an existing script, point config at it directly:
+
+```yaml
+# POSIX
+escalation:
+  command: '/path/to/escalation.sh'
+
+# Windows
+escalation:
+  command: 'powershell -NoProfile -File C:\path\escalation.ps1'
+```

--- a/README.md
+++ b/README.md
@@ -170,7 +170,15 @@ Full spec at [jmespath.org](https://jmespath.org). `jq` and other tools (Python,
 
 ### Escalation hook recipes
 
-The hook fires only when checkout `result.status === "requires_escalation"`; message severities such as `requires_buyer_input` / `requires_buyer_review` affect framing, not the firing condition. It receives a compact payload (`status`, `url`, `reason`, `business`, `operation`) as JSON on stdin. Auth-class errors such as `AUTH_REQUIRED` / `INSUFFICIENT_PERMISSIONS` do not fire the hook; they return structured error CTAs so the agent can hand the buyer off using the best URL it already has. Configure per-call with `--on-escalation '<cmd>'`, sticky across a shell session with `export UCP_ON_ESCALATION='<cmd>'`, or persistently via `~/.ucp/config.yaml` (`escalation.command`) or an executable `~/.ucp/hooks/escalation`. Resolution order: per-call flag wins, then env, then config, then hook file. The hook-file convention is POSIX-oriented; on Windows prefer a shell command via flag/env/config.
+Fires when checkout `result.status === "requires_escalation"`. Receives a compact JSON payload (`status`, `url`, `reason`, `business`, `operation`) on stdin. Auth-class errors (`AUTH_REQUIRED`, `INSUFFICIENT_PERMISSIONS`) do **not** fire the hook — they return structured error CTAs so the agent can hand off using the best URL it already has.
+
+Configure one (first match wins):
+
+- **Per-call flag** — `ucp <op> --on-escalation '<cmd>'`
+- **Env var** — `export UCP_ON_ESCALATION='<cmd>'` (most common)
+- **Persistent config** — `~/.ucp/config.yaml`: `escalation.command: '<cmd>'`
+
+`<cmd>` runs through `/bin/sh -c` on POSIX and `cmd.exe /d /s /c` on Windows. To run an existing script, point at it directly: `'/path/to/escalation.sh'` (POSIX) or `'powershell -NoProfile -File C:\path\escalation.ps1'` (Windows).
 
 One-shot, interactive (browser open):
 

--- a/skills/ucp/SKILL.md
+++ b/skills/ucp/SKILL.md
@@ -236,10 +236,9 @@ Configure one source (first match wins):
 ucp <op> --on-escalation '<command>'       # per-call flag
 export UCP_ON_ESCALATION='<command>'       # env var (most common)
 # Or ~/.ucp/config.yaml: escalation: { command: '<command>' }
-# Or POSIX: ~/.ucp/hooks/escalation (executable file; payload on stdin)
 ```
 
-On Windows, prefer flag/env/config shell commands; the hook-file convention is POSIX-oriented.
+Commands run through `/bin/sh -c` on POSIX, `cmd.exe /d /s /c` on Windows. To run an existing script, point at it directly: `'/path/to/escalation.sh'` (POSIX) or `'powershell -NoProfile -File C:\path\escalation.ps1'` (Windows).
 
 **Common hook examples:**
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1060,7 +1060,7 @@ describe('createUcpCli — escalation hook', () => {
       completeCheckout: async () => ESCALATION_RESULT,
       resolveEscalationHook: async (opts) => {
         resolveCalls.push(opts)
-        return { source: 'env', command: 'echo run', isFile: false }
+        return { source: 'env', command: 'echo run' }
       },
       runEscalationHook: async (opts) => {
         runCalls.push({
@@ -1101,7 +1101,7 @@ describe('createUcpCli — escalation hook', () => {
     const firstCall = runCalls[0]
     if (firstCall === undefined) throw new Error('expected a runCall')
     expect(firstCall.skip).toBeUndefined()
-    expect(firstCall.hook).toEqual({ source: 'env', command: 'echo run', isFile: false })
+    expect(firstCall.hook).toEqual({ source: 'env', command: 'echo run' })
     // Payload built from checkout object: status, continue_url → url, message content → reason.
     expect(firstCall.payload).toMatchObject({
       status: 'requires_escalation',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1093,7 +1093,7 @@ function businessNotResolvedError(): ErrorEnvelopeOpts {
   }
 }
 
-// Resolve the escalation hook (per the four-source resolution order documented
+// Resolve the escalation hook (per the three-source resolution order documented
 // in src/core/escalation.ts) and fire it. Always async-await before returning
 // the checkout envelope: the hook is *notification*, not gating, but sending
 // the Slack/browser notification before the agent sees the result keeps the

--- a/src/core/escalation.test.ts
+++ b/src/core/escalation.test.ts
@@ -1,11 +1,12 @@
 // Escalation hook: resolution order + JSON-on-stdin contract + MCP no-op.
 
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { platform } from 'node:process'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { nodeHookCommand } from '../../test/fixtures/shell-command.js'
 
 import {
   buildEscalationPayload,
@@ -35,18 +36,6 @@ const SAMPLE_PAYLOAD: EscalationPayload = {
   reason: '3DS challenge required',
   business: 'https://shop.example.com',
   operation: 'complete_checkout',
-}
-
-// Use temp script files instead of inline `node -e` snippets: Windows cmd.exe
-// quote-stripping turns those snippets into a test of shell parser trivia rather
-// than the escalation hook contract.
-function shellArg(value: string): string {
-  if (platform === 'win32') return `"${value.replace(/"/g, '""')}"`
-  return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-function nodeHookCommand(script: string, ...args: string[]): string {
-  return ['node', shellArg(script), ...args.map(shellArg)].join(' ')
 }
 
 async function writeHookScript(dir: string, name: string, source: string): Promise<string> {
@@ -165,11 +154,7 @@ describe('resolveEscalationHook', () => {
     expect(await resolveEscalationHook({ env: {}, homeDir })).toBeUndefined()
   })
 
-  it('argFlag wins over env, config, and file', async () => {
-    await mkdir(join(homeDir, 'hooks'), { recursive: true })
-    const filePath = join(homeDir, 'hooks', 'escalation')
-    await writeFile(filePath, '#!/bin/sh\necho file', 'utf-8')
-    await chmod(filePath, 0o755)
+  it('argFlag wins over env and config', async () => {
     await writeFile(join(homeDir, 'config.yaml'), 'escalation:\n  command: echo config\n', 'utf-8')
 
     const hook = await resolveEscalationHook({
@@ -177,56 +162,38 @@ describe('resolveEscalationHook', () => {
       env: { UCP_ON_ESCALATION: 'echo env' },
       homeDir,
     })
-    expect(hook).toEqual({ source: 'flag', command: 'echo flag', isFile: false })
+    expect(hook).toEqual({ source: 'flag', command: 'echo flag' })
   })
 
-  it('env wins over config and file', async () => {
-    await mkdir(join(homeDir, 'hooks'), { recursive: true })
-    const filePath = join(homeDir, 'hooks', 'escalation')
-    await writeFile(filePath, '#!/bin/sh\necho file', 'utf-8')
-    await chmod(filePath, 0o755)
+  it('env wins over config', async () => {
     await writeFile(join(homeDir, 'config.yaml'), 'escalation:\n  command: echo config\n', 'utf-8')
 
     const hook = await resolveEscalationHook({
       env: { UCP_ON_ESCALATION: 'echo env' },
       homeDir,
     })
-    expect(hook).toEqual({ source: 'env', command: 'echo env', isFile: false })
+    expect(hook).toEqual({ source: 'env', command: 'echo env' })
   })
 
-  it('config.yaml wins over file', async () => {
-    await mkdir(join(homeDir, 'hooks'), { recursive: true })
-    const filePath = join(homeDir, 'hooks', 'escalation')
-    await writeFile(filePath, '#!/bin/sh\necho file', 'utf-8')
-    await chmod(filePath, 0o755)
+  it('config.yaml is the lowest-priority source', async () => {
     await writeFile(join(homeDir, 'config.yaml'), 'escalation:\n  command: echo config\n', 'utf-8')
 
     const hook = await resolveEscalationHook({ env: {}, homeDir })
-    expect(hook).toEqual({ source: 'config', command: 'echo config', isFile: false })
-  })
-
-  it('file convention is the lowest-priority source', async () => {
-    await mkdir(join(homeDir, 'hooks'), { recursive: true })
-    const filePath = join(homeDir, 'hooks', 'escalation')
-    await writeFile(filePath, '#!/bin/sh\necho file', 'utf-8')
-    await chmod(filePath, 0o755)
-
-    const hook = await resolveEscalationHook({ env: {}, homeDir })
-    expect(hook).toEqual({ source: 'file', command: filePath, isFile: true })
+    expect(hook).toEqual({ source: 'config', command: 'echo config' })
   })
 
   it.each([
     ['empty argFlag', { argFlag: '', env: { UCP_ON_ESCALATION: 'echo env' } }],
     ['empty env', { env: { UCP_ON_ESCALATION: '' } }],
   ])('treats %s as not-set so unsetting falls through', async (_, opts) => {
-    // No config.yaml, no hook file ⇒ should resolve to undefined when both
-    // upper sources are explicitly empty.
+    // No config.yaml ⇒ should resolve to undefined when both upper sources are
+    // explicitly empty.
     const hook = await resolveEscalationHook({ ...opts, homeDir })
     if ('env' in opts && opts.env.UCP_ON_ESCALATION === '') {
       expect(hook).toBeUndefined()
     } else {
       // empty argFlag falls through to env
-      expect(hook).toEqual({ source: 'env', command: 'echo env', isFile: false })
+      expect(hook).toEqual({ source: 'env', command: 'echo env' })
     }
   })
 
@@ -242,20 +209,12 @@ describe('resolveEscalationHook', () => {
     await writeFile(join(homeDir, 'config.yaml'), 'escalation:\n  command: 5\n', 'utf-8')
     expect(await resolveEscalationHook({ env: {}, homeDir })).toBeUndefined()
   })
-
-  it.skipIf(platform === 'win32')('ignores hooks/escalation when not executable', async () => {
-    await mkdir(join(homeDir, 'hooks'), { recursive: true })
-    const filePath = join(homeDir, 'hooks', 'escalation')
-    await writeFile(filePath, '#!/bin/sh\necho file', 'utf-8')
-    await chmod(filePath, 0o644)
-    expect(await resolveEscalationHook({ env: {}, homeDir })).toBeUndefined()
-  })
 })
 
 describe('runEscalationHook', () => {
   it('returns invoked=false with reason=mcp-mode when skip=true', async () => {
     const result = await runEscalationHook({
-      hook: { source: 'env', command: 'echo should-not-run', isFile: false },
+      hook: { source: 'env', command: 'echo should-not-run' },
       payload: SAMPLE_PAYLOAD,
       skip: true,
     })
@@ -284,7 +243,6 @@ describe('runEscalationHook', () => {
         hook: {
           source: 'env',
           command: nodeHookCommand(captureScript, captureFile),
-          isFile: false,
         },
         payload: SAMPLE_PAYLOAD,
         stderr,
@@ -316,7 +274,6 @@ describe('runEscalationHook', () => {
         hook: {
           source: 'env',
           command: nodeHookCommand(script),
-          isFile: false,
         },
         payload: SAMPLE_PAYLOAD,
         stderr,
@@ -343,7 +300,6 @@ describe('runEscalationHook', () => {
         hook: {
           source: 'env',
           command: nodeHookCommand(script),
-          isFile: false,
         },
         payload: SAMPLE_PAYLOAD,
         stderr,
@@ -363,7 +319,7 @@ describe('runEscalationHook', () => {
       const script = await writeHookScript(tmpDir, 'exit.cjs', 'process.exit(7)\n')
       const stderr = new StderrSink()
       const result = await runEscalationHook({
-        hook: { source: 'env', command: nodeHookCommand(script), isFile: false },
+        hook: { source: 'env', command: nodeHookCommand(script) },
         payload: SAMPLE_PAYLOAD,
         stderr,
       })
@@ -377,16 +333,17 @@ describe('runEscalationHook', () => {
     }
   })
 
-  it('logs spawn-failure when the hook executable is missing', async () => {
+  it('logs spawn-failure when the shell binary is missing', async () => {
+    // With the file-source convention removed, every hook routes through the
+    // shell. The remaining spawn-failure path is the shell binary itself being
+    // absent — inject it explicitly so we exercise the child.on('error') branch
+    // without relying on a platform path that happens to not exist.
     const stderr = new StderrSink()
     const result = await runEscalationHook({
-      hook: {
-        source: 'file',
-        command: '/nonexistent/path/to/hook-binary-that-does-not-exist',
-        isFile: true,
-      },
+      hook: { source: 'env', command: 'echo unused' },
       payload: SAMPLE_PAYLOAD,
       stderr,
+      shell: '/nonexistent/path/to/shell-binary-that-does-not-exist',
     })
     expect(result.invoked).toBe(true)
     if (result.invoked) {
@@ -405,7 +362,7 @@ describe('runEscalationHook', () => {
       )
       const stderr = new StderrSink()
       const result = await runEscalationHook({
-        hook: { source: 'env', command: nodeHookCommand(script), isFile: false },
+        hook: { source: 'env', command: nodeHookCommand(script) },
         payload: SAMPLE_PAYLOAD,
         stderr,
         timeoutMs: 100,
@@ -429,7 +386,7 @@ describe('runEscalationHook', () => {
     try {
       const script = await writeHookScript(tmpDir, 'stdout.cjs', "console.log('SHOULD-NOT-LEAK')\n")
       const result = await runEscalationHook({
-        hook: { source: 'env', command: nodeHookCommand(script), isFile: false },
+        hook: { source: 'env', command: nodeHookCommand(script) },
         payload: SAMPLE_PAYLOAD,
       })
       expect(result.invoked).toBe(true)

--- a/src/core/escalation.ts
+++ b/src/core/escalation.ts
@@ -7,24 +7,31 @@
 // the structured checkout response).
 //
 // Resolution order (first match wins):
-//   1. CLI flag         --on-escalation '<cmd>'
-//   2. Env var          UCP_ON_ESCALATION='<cmd>'
-//   3. Config field     ~/.ucp/config.yaml: escalation.command
-//   4. File convention  ~/.ucp/hooks/escalation  (executable)
+//   1. CLI flag      --on-escalation '<cmd>'
+//   2. Env var       UCP_ON_ESCALATION='<cmd>'
+//   3. Config field  ~/.ucp/config.yaml: escalation.command
 //
-// 1–3 are shell command lines run through the platform shell (`/bin/sh -c` on
-// POSIX, `cmd.exe /d /s /c` on Windows). 4 is an executable spawned directly.
-// Going single-command + JSON-on-stdin instead of typed hook kinds keeps the
-// CLI's surface tiny and lets users compose browsers, Slack, notifications,
-// etc. via shell pipes they already know.
+// All sources are shell command strings run through the platform shell
+// (`/bin/sh -c` on POSIX, `cmd.exe /d /s /c` on Windows). One contract, one
+// model, identical on every OS. Going single-command + JSON-on-stdin instead
+// of typed hook kinds keeps the CLI's surface tiny and lets users compose
+// browsers, Slack, notifications, etc. via shell pipes they already know.
+//
+// Earlier versions also supported a POSIX-only file convention
+// (`~/.ucp/hooks/escalation`, executable). It was dropped because:
+//   - it duplicated config-source (“put your command in a file” vs “point
+//     config at a file”),
+//   - its `X_OK` executability check has no Windows-meaningful semantics,
+//   - it introduced platform asymmetry users had to learn around.
+// Users who want “drop a script and run it” should reference the script from
+// config: `escalation.command: '/path/to/escalation.sh'`.
 //
 // MCP server mode is a no-op: an MCP server must not surprise the host
 // process by spawning subprocesses or opening browsers. The structured
 // envelope reaches the agent regardless.
 
 import { type SpawnOptions, spawn } from 'node:child_process'
-import { constants as fsConstants } from 'node:fs'
-import { access, readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { parse as parseYaml } from 'yaml'
@@ -45,14 +52,12 @@ export interface EscalationPayload {
   structured_action?: Record<string, unknown>
 }
 
-export type HookSource = 'flag' | 'env' | 'config' | 'file'
+export type HookSource = 'flag' | 'env' | 'config'
 
 export interface EscalationHook {
   source: HookSource
-  /** Shell command (sources flag/env/config) or executable path (source file). */
+  /** Shell command line. Always run through the platform shell. */
   command: string
-  /** True for source=file: spawn the path directly with no shell. */
-  isFile: boolean
 }
 
 export interface ResolveHookOptions {
@@ -65,7 +70,7 @@ export interface ResolveHookOptions {
 }
 
 /**
- * Walk the four sources in order; return the first match. Empty strings are
+ * Walk the three sources in order; return the first match. Empty strings are
  * treated as not-set so `UCP_ON_ESCALATION=` falls through to lower-priority
  * sources — otherwise users can't unset an inherited value.
  */
@@ -73,21 +78,17 @@ export async function resolveEscalationHook(
   opts: ResolveHookOptions = {},
 ): Promise<EscalationHook | undefined> {
   if (opts.argFlag !== undefined && opts.argFlag.length > 0) {
-    return { source: 'flag', command: opts.argFlag, isFile: false }
+    return { source: 'flag', command: opts.argFlag }
   }
   const env = opts.env ?? process.env
   const envCmd = env.UCP_ON_ESCALATION
   if (typeof envCmd === 'string' && envCmd.length > 0) {
-    return { source: 'env', command: envCmd, isFile: false }
+    return { source: 'env', command: envCmd }
   }
   const home = profileStoreHome({ ...(opts.homeDir !== undefined && { homeDir: opts.homeDir }) })
   const configCmd = await readConfigCommand(home)
   if (configCmd !== undefined) {
-    return { source: 'config', command: configCmd, isFile: false }
-  }
-  const filePath = join(home, 'hooks', 'escalation')
-  if (await isExecutable(filePath)) {
-    return { source: 'file', command: filePath, isFile: true }
+    return { source: 'config', command: configCmd }
   }
   return undefined
 }
@@ -110,17 +111,6 @@ async function readConfigCommand(home: string): Promise<string | undefined> {
   if (typeof escalation !== 'object' || escalation === null) return undefined
   const command = (escalation as Record<string, unknown>).command
   return typeof command === 'string' && command.length > 0 ? command : undefined
-}
-
-async function isExecutable(path: string): Promise<boolean> {
-  try {
-    const s = await stat(path)
-    if (!s.isFile()) return false
-    await access(path, fsConstants.X_OK)
-    return true
-  } catch {
-    return false
-  }
 }
 
 export type RunHookResult =
@@ -190,14 +180,11 @@ export async function runEscalationHook(opts: RunHookOptions): Promise<RunHookRe
       // For `cmd.exe /c <command>`, Node's default Windows argv quoting escapes
       // inner quotes before cmd parses them. That makes commands like
       // `node "C:\\Temp\\hook.cjs"` reach Node with literal quote characters in
-      // argv[1]. Shell hooks already provide a complete command string, so pass
+      // argv[1]. Shell hooks always provide a complete command string, so pass
       // the cmd argv through verbatim and let cmd own command-string parsing.
-      windowsVerbatimArguments:
-        process.platform === 'win32' && !hook.isFile && usesDefaultPlatformShell,
+      windowsVerbatimArguments: process.platform === 'win32' && usesDefaultPlatformShell,
     }
-    const child = hook.isFile
-      ? spawn(hook.command, [], spawnOptions)
-      : spawn(shell, shellArgs, spawnOptions)
+    const child = spawn(shell, shellArgs, spawnOptions)
 
     const timer = setTimeout(() => {
       timedOut = true

--- a/test/fixtures/shell-command.ts
+++ b/test/fixtures/shell-command.ts
@@ -1,0 +1,10 @@
+import { platform } from 'node:process'
+
+export function shellArg(value: string): string {
+  if (platform === 'win32') return `"${value.replace(/"/g, '""')}"`
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+export function nodeHookCommand(script: string, ...args: string[]): string {
+  return ['node', shellArg(script), ...args.map(shellArg)].join(' ')
+}

--- a/test/integration/purchase-journey.integration.test.ts
+++ b/test/integration/purchase-journey.integration.test.ts
@@ -1,11 +1,19 @@
 // Purchase journey integration test.
 //
 // Drives the compiled CLI through the full UCP shopping flow against a local
-// mock business and measures:
+// mock business and measures what only end-to-end execution can prove:
 //   1. Each step produces clean, unwrapped output (not raw MCP envelopes).
 //   2. Every op success response carries a `cta` pointing at the next step.
-//   3. complete_checkout triggers a requires_buyer_review escalation.
-//   4. The escalation hook fires and receives the correct JSON payload.
+//   3. complete_checkout returns a requires_buyer_review escalation envelope
+//      with the right CTA copy and exit code.
+//
+// Escalation hook spawning (env/flag/config sources, shell quoting, stdin
+// payload, exit-code/timeout/EPIPE handling) is covered exhaustively in
+// `src/core/escalation.test.ts`. The CLI wiring that calls resolveHook +
+// runHook on a requires_escalation response is covered in `src/cli.test.ts`.
+// Re-asserting subprocess plumbing here would only test the platform shell,
+// not the journey — and it would couple this test to cmd.exe quoting on
+// Windows for no integration-level signal.
 //
 // Treat this as an agent-fidelity check: does an agent following SKILL.md
 // and CLI output alone have everything it needs to complete the flow
@@ -15,7 +23,7 @@
 // Runs against the packaged bin entry — `pnpm test:integration` builds first.
 
 import { execFile } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -29,7 +37,6 @@ import {
   MOCK_VARIANT_ID,
   startMockUcpShopping,
 } from '../fixtures/mock-ucp-shopping.js'
-import { nodeHookCommand } from '../fixtures/shell-command.js'
 
 const execFileAsync = promisify(execFile)
 const CLI = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
@@ -37,7 +44,6 @@ const CLI = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
 interface Journey {
   businessUrl: string
   ucpHome: string
-  hookCapturePath: string
   run(
     args: string[],
     extraEnv?: Record<string, string>,
@@ -48,7 +54,6 @@ interface Journey {
 async function setupJourney(): Promise<Journey> {
   const mock = await startMockUcpShopping()
   const ucpHome = await mkdtemp(join(tmpdir(), 'ucp-eval-'))
-  const hookCapturePath = join(ucpHome, 'escalation-payload.json')
 
   // Minimal agent profile so the CLI can resolve a profileUrl.
   const profileDir = join(ucpHome, 'profiles', 'eval')
@@ -85,23 +90,9 @@ async function setupJourney(): Promise<Journey> {
   // Allow the mock server's http://127.0.0.1 URL through the https-only guard.
   // TEST infix is intentional: this is not a production/deployment knob.
   baseEnv.UCP_TEST_ALLOW_INSECURE_LOCALHOST = 'true'
-  // Hook writes payload to file so assertions can read it. Use a tiny Node
-  // program instead of shell redirection: CI runs this integration suite on
-  // Windows too, where `cat > 'path'` is not portable.
-  const hookCaptureScript = join(ucpHome, 'capture-escalation.cjs')
-  await writeFile(
-    hookCaptureScript,
-    "process.stdin.pipe(require('node:fs').createWriteStream(process.argv[2]))\n",
-    'utf-8',
-  )
-  // This is a shell command because UCP_ON_ESCALATION intentionally accepts
-  // the same user-facing command string as --on-escalation. Do not use
-  // JSON.stringify for path quoting here: it produces JavaScript string
-  // escapes, not shell quoting, and Windows + Node 24 can crash before the CLI
-  // reports the hook result. The shared helper is intentionally test-only:
-  // this integration test is about end-to-end hook firing, not about fuzzing
-  // cmd.exe quoting.
-  baseEnv.UCP_ON_ESCALATION = nodeHookCommand(hookCaptureScript, hookCapturePath)
+  // Intentionally do not set UCP_ON_ESCALATION. Hook resolution + spawn is
+  // unit-tested; here we only assert the CLI handles requires_escalation
+  // correctly (envelope, CTA, exit code, stderr quiet by default).
 
   const run = async (
     args: string[],
@@ -129,7 +120,6 @@ async function setupJourney(): Promise<Journey> {
   return {
     businessUrl: mock.url,
     ucpHome,
-    hookCapturePath,
     run,
     async close() {
       await mock.close()
@@ -289,7 +279,7 @@ describe('eval: purchase journey', () => {
 
   // ─── Step 5: complete + escalation ────────────────────────────────────────
 
-  it('step 5 — complete_checkout: escalation envelope + hook fires with payload', async () => {
+  it('step 5 — complete_checkout: requires_escalation envelope + CTA copy + exits 0', async () => {
     const { json, code, stderr } = await j.run(['checkout', 'complete', MOCK_CHECKOUT_ID])
 
     // CLI exits 0 — requires_escalation is a normal UCP checkout response.
@@ -302,19 +292,9 @@ describe('eval: purchase journey', () => {
     expect(checkout.continue_url).toBe(MOCK_ESCALATION_URL)
 
     // Default CLI output is quiet on stderr for protocol-state changes:
-    // requires_escalation is represented by the structured checkout result,
-    // CTA, and hook payload. Human breadcrumbs are opt-in via --verbose.
+    // requires_escalation is represented by the structured checkout result
+    // and CTA. Human breadcrumbs are opt-in via --verbose.
     expect(stderr).not.toMatch(/\[ucp\] escalation \[complete_checkout\]/i)
-
-    // Hook fired: the capture file should contain the JSON payload.
-    const captured = JSON.parse(await readFile(j.hookCapturePath, 'utf-8')) as Record<
-      string,
-      unknown
-    >
-    // Payload built from flat checkout response: status is top-level field.
-    expect(captured.status).toBe('requires_escalation')
-    expect(captured.url).toBe(MOCK_ESCALATION_URL)
-    expect(captured.operation).toBe('complete_checkout')
 
     // CTA must be messages-aware: mock returns requires_buyer_review (checkout complete,
     // buyer authorizes). Description must distinguish this from requires_buyer_input

--- a/test/integration/purchase-journey.integration.test.ts
+++ b/test/integration/purchase-journey.integration.test.ts
@@ -29,6 +29,7 @@ import {
   MOCK_VARIANT_ID,
   startMockUcpShopping,
 } from '../fixtures/mock-ucp-shopping.js'
+import { nodeHookCommand } from '../fixtures/shell-command.js'
 
 const execFileAsync = promisify(execFile)
 const CLI = fileURLToPath(new URL('../../dist/bin.js', import.meta.url))
@@ -93,7 +94,14 @@ async function setupJourney(): Promise<Journey> {
     "process.stdin.pipe(require('node:fs').createWriteStream(process.argv[2]))\n",
     'utf-8',
   )
-  baseEnv.UCP_ON_ESCALATION = `node ${JSON.stringify(hookCaptureScript)} ${JSON.stringify(hookCapturePath)}`
+  // This is a shell command because UCP_ON_ESCALATION intentionally accepts
+  // the same user-facing command string as --on-escalation. Do not use
+  // JSON.stringify for path quoting here: it produces JavaScript string
+  // escapes, not shell quoting, and Windows + Node 24 can crash before the CLI
+  // reports the hook result. The shared helper is intentionally test-only:
+  // this integration test is about end-to-end hook firing, not about fuzzing
+  // cmd.exe quoting.
+  baseEnv.UCP_ON_ESCALATION = nodeHookCommand(hookCaptureScript, hookCapturePath)
 
   const run = async (
     args: string[],

--- a/test/integration/smoke.integration.test.ts
+++ b/test/integration/smoke.integration.test.ts
@@ -35,6 +35,19 @@ describe('smoke: compiled binary', () => {
     expect(code).toBe(0)
   })
 
+  // Package managers (npm, pnpm, brew) install POSIX bins as symlinks pointing
+  // into node_modules/.../dist/bin.js, so the CLI must run when reached via a
+  // symlink (not just via the realpath). Earlier versions had a
+  // `process.argv[1] === fileURLToPath(import.meta.url)` guard in src/cli.ts
+  // that silently no-op'd for symlinks; src/bin.ts now unconditionally calls
+  // runUcpCli(), so this failure class is architecturally impossible — this
+  // test catches any future re-introduction cheaply (no pack/install needed).
+  //
+  // Skipped on Windows because (a) fs.symlink requires admin / Developer Mode
+  // by default, and (b) Windows package managers install bins as .cmd shims
+  // rather than symlinks, so a symlink probe wouldn't model real Windows
+  // install behavior anyway. The Windows installed-bin path is covered by the
+  // `real pnpm add -g` CI job, which uses the actual platform mechanism.
   it.skipIf(platform() === 'win32')(
     'serves when invoked through an installed-bin symlink',
     async () => {


### PR DESCRIPTION
Drops the POSIX-only `~/.ucp/hooks/escalation` file convention. The hook contract is now three sources (`--on-escalation` flag, `UCP_ON_ESCALATION` env, `~/.ucp/config.yaml` `escalation.command`) all shell command strings, identical on every OS. Simple and symmetric.

The file convention was a POSIX ergonomic that didn't translate to Windows:
- It duplicated config-source ("put your command in a file" vs "point config at a file").
- `fs.access(X_OK)` has no Windows-meaningful semantics; Windows determines executability by file extension, not bit.
- It forced platform asymmetry users had to learn around.

Config-source covers the "drop a script and run it" use case fine:

```yaml
# POSIX
escalation:
  command: '/path/to/escalation.sh'

# Windows
escalation:
  command: 'powershell -NoProfile -File C:\path\escalation.ps1'
```

