### PR TITLE
Update UCP link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `@shopify/ucp-cli`
 
-**A shopping skill for AI agents, powered by the [Universal Commerce Protocol](https://github.com/Shopify/ucp-spec).**
+**A shopping skill for AI agents, powered by the [Universal Commerce Protocol](https://github.com/Universal-Commerce-Protocol/ucp).**
 
 - **Search products across millions of merchants** via a unified global catalog
 - **Build carts and complete checkouts** against any UCP-enabled merchant


### PR DESCRIPTION
The README > UCP spec link was stale, and this PR updates that link to the correct location https://github.com/Universal-Commerce-Protocol/ucp . 

I also see the ucp.dev link, but I think the GitHub link would look more polished for the GitHub README. I am not completely sure, so feel free to adjust it.