### PR TITLE
Use Changesets publish flow for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prepublishOnly": "pnpm build",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm build && pnpm publish --no-git-checks --access public"
+    "release": "pnpm build && pnpm changeset publish"
   },
   "dependencies": {
     "@jmespath-community/jmespath": "^1.3.0",


### PR DESCRIPTION
## Summary
- update the release script to call `changeset publish` instead of raw `pnpm publish`
- preserve the build step before publishing

## Why
When Changesets finds no changesets, it may still invoke the publish command to publish any already-versioned but unpublished packages. The previous raw `pnpm publish` command retried the current package.json version unconditionally and failed when that version was already on npm. `changeset publish` checks npm state and no-ops when there is nothing unpublished.

## Test
- `pnpm changeset publish --help`
- `pnpm build`