### PR TITLE
fix: Ajv2020 validation + verbose/strict mode

### DIFF
--- a/.changeset/ajv-2020-dialect-soft-fail.md
+++ b/.changeset/ajv-2020-dialect-soft-fail.md
@@ -1,0 +1,57 @@
+---
+"@shopify/ucp-cli": patch
+---
+
+Fix `MCP_INVALID_RESPONSE` errors on every dispatch against businesses that
+publish JSON Schema draft 2020-12 inputSchemas, and make client-side
+pre-flight validation best-effort instead of fail-closed.
+
+The pre-flight input validator previously used AJV's draft-07-only build and
+threw on the 2020-12 meta-schema URI (`https://json-schema.org/draft/2020-12/schema`)
+before inspecting any payload. Every `catalog search`, `cart create`,
+`checkout *`, and `order *` call against MCP servers that advertise the
+2020-12 dialect returned:
+
+```
+MCP_INVALID_RESPONSE: business returned an invalid input schema for "<tool>"
+Details: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
+```
+
+Three changes:
+
+1. **2020-12 dialect support.** The validator now uses AJV's 2020-12 build
+   (`Ajv2020`), which registers the 2020-12 meta-schema. Schemas declaring
+   2020-12 — or no `$schema` at all — compile and validate normally.
+
+2. **Soft signals replace hard throws for client-side uncertainty.** When
+   the published schema cannot be compiled (unknown dialect, malformed JSON
+   Schema) or when an argument carries a plain key not listed in the
+   published schema, the dispatcher no longer fails the call. The server is
+   the authoritative validator and returns `SCHEMA_VALIDATION_FAILED` for
+   genuinely bad payloads. Three modes:
+
+   - **default** — silent; the request proceeds and the server decides.
+   - **`--verbose` / `UCP_VERBOSE=1`** — emit a `vlog()` trace so operators
+     can see what was flagged and why.
+   - **`UCP_STRICT_SCHEMA=1`** — restore the throw (`MCP_INVALID_RESPONSE`
+     for compile failures, `SCHEMA_VALIDATION_FAILED` for unknown plain
+     keys). Useful in CI or for paranoid local development.
+
+   Payload validation against a successfully compiled schema still throws
+   `SCHEMA_VALIDATION_FAILED` in every mode — local typo-catching saves a
+   server round-trip.
+
+3. **Removed `patchKnownUpstreamSchemaDefects` (the `\A` regex stopgap).**
+   The upstream defect it worked around is fixed in production, and the
+   new soft-fail path handles any future regex-incompatibility regression
+   without a hard failure.
+
+Upgrade impact:
+
+- Agents and scripts that previously branched on `MCP_INVALID_RESPONSE` from
+  the pre-flight path will no longer see it in the default mode. Set
+  `UCP_STRICT_SCHEMA=1` to restore the old strict behavior.
+- The previous client-side rejection of "unknown plain fields" no longer
+  fires by default. Reverse-DNS extension keys remain the recommended
+  convention; the CLI just doesn't enforce it client-side anymore.
+- No new error codes.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ There is no `--auth-bearer` flag and no `UCP_AUTH_BEARER` env var. `--header` is
 | `UCP_ON_ESCALATION` | Shell command for the escalation hook (JSON payload on stdin) |
 | `UCP_HOME` | Override the local state directory (default `~/.ucp`) |
 | `UCP_VERBOSE` | Set `1`/`true` to print trace lines to stderr |
+| `UCP_STRICT_SCHEMA` | Set `1`/`true` to make client-side input validation fail-closed: throw `MCP_INVALID_RESPONSE` when the published input schema can't be compiled, and `SCHEMA_VALIDATION_FAILED` when a payload carries plain keys not listed in the schema. Default is silent + dispatch (the server is the authoritative validator); `--verbose` surfaces these as traces. |
 
 
 ## Development

--- a/src/core/operation.test.ts
+++ b/src/core/operation.test.ts
@@ -10,13 +10,9 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  callOperation,
-  isDryRunPreview,
-  patchKnownUpstreamSchemaDefects,
-  unwrapMcpCallResult,
-} from './operation.js'
+import { callOperation, isDryRunPreview, unwrapMcpCallResult } from './operation.js'
 import type { AgentRange } from './profile.js'
+import { setVerboseWriter } from './verbose.js'
 
 const BUSINESS_URL = 'https://shop.example.invalid'
 const MCP_ENDPOINT = 'https://shop.example.invalid/ucp/mcp'
@@ -33,7 +29,11 @@ const PROFILE = {
   },
 }
 
+// Declares `$schema` so the dispatcher exercises the JSON Schema dialect
+// path real servers publish. Fixtures without `$schema` silently default to
+// draft-07 and mask validator/dialect mismatches.
 const SEARCH_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   required: ['meta', 'catalog'],
   properties: {
@@ -291,77 +291,6 @@ describe('callOperation', () => {
     expect(bodies.some((body) => body.method === 'tools/call')).toBe(false)
   })
 
-  it('rejects unknown plain fields before tools/call even when schema allows extensions', async () => {
-    const bodies: Record<string, unknown>[] = []
-    const fetch = vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
-      const u = String(url)
-      const body =
-        typeof init.body === 'string'
-          ? (JSON.parse(init.body) as Record<string, unknown>)
-          : undefined
-      if (body !== undefined) bodies.push(body)
-      if (u.endsWith('/.well-known/ucp')) return jsonResponse(PROFILE)
-      return jsonResponse({
-        jsonrpc: '2.0',
-        id: body?.id,
-        result: { tools: [{ name: 'search_catalog', inputSchema: SEARCH_SCHEMA }] },
-      })
-    }) as unknown as typeof globalThis.fetch
-
-    await expect(
-      callOperation(
-        BUSINESS_URL,
-        {
-          capability: 'dev.ucp.shopping',
-          toolName: 'search_catalog',
-          input: {
-            catalog: {
-              query: 'boots',
-              context: {
-                address_country: 'US',
-                address_subdivision: 'CA',
-                address_postal_code: '94105',
-              },
-            },
-          },
-        },
-        { cacheDir, agentRange: RANGE, fetch, profileUrl: PROFILE_URL },
-      ),
-    ).rejects.toMatchObject({
-      code: 'SCHEMA_VALIDATION_FAILED',
-      layer: 'client',
-      context: {
-        unknown_fields: [
-          '/catalog/context/address_subdivision',
-          '/catalog/context/address_postal_code',
-        ],
-      },
-    })
-
-    await expect(
-      callOperation(
-        BUSINESS_URL,
-        {
-          capability: 'dev.ucp.shopping',
-          toolName: 'search_catalog',
-          input: {
-            catalog: {
-              query: 'boots',
-              context: { address_country: 'US', 'Com.Example.fulfillment_hint': 'dock' },
-            },
-          },
-        },
-        { cacheDir, agentRange: RANGE, fetch, profileUrl: PROFILE_URL },
-      ),
-    ).rejects.toMatchObject({
-      code: 'SCHEMA_VALIDATION_FAILED',
-      layer: 'client',
-      context: { unknown_fields: ['/catalog/context/Com.Example.fulfillment_hint'] },
-    })
-
-    expect(bodies.some((body) => body.method === 'tools/call')).toBe(false)
-  })
-
   it('allows reverse-DNS extension keys at open schema extension points', async () => {
     const bodies: Record<string, unknown>[] = []
     const fetch = vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
@@ -575,7 +504,268 @@ describe('callOperation', () => {
   })
 })
 
-// TODO(upstream-fix): delete this block alongside patchKnownUpstreamSchemaDefects.
+// Tri-mode test matrix for pre-flight input validation. The dispatcher
+// distinguishes "soft" signals (uncertainty, policy opinion) from "hard"
+// signals (proven payload defect):
+//
+//   soft = schema cannot be compiled, or args carry a plain key not listed
+//          in the published schema. Default = silent + proceed; verbose =
+//          vlog trace + proceed; UCP_STRICT_SCHEMA=1 = throw.
+//
+//   hard = args fail validation against a successfully compiled schema.
+//          Always throws SCHEMA_VALIDATION_FAILED regardless of mode —
+//          local typo-catching saves a server round-trip.
+//
+// These tests pin the policy. Tweak with care: each row is a deliberate
+// trade-off between agent UX (silent fast path) and operator debuggability
+// (verbose) and contract enforcement (strict).
+describe('validateOperationInput — dialect resilience and soft signals', () => {
+  let cacheDir: string
+  let verboseLines: string[]
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'ucp-cli-dialect-test-'))
+    verboseLines = []
+    setVerboseWriter((msg) => {
+      verboseLines.push(msg)
+    })
+  })
+
+  afterEach(async () => {
+    setVerboseWriter(null)
+    delete process.env.UCP_STRICT_SCHEMA
+    await rm(cacheDir, { recursive: true, force: true })
+  })
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+  // Build a fetch that records tools/call method names so tests can prove
+  // the dispatcher actually reached the wire (vs failing closed locally).
+  function buildFetch(inputSchema: unknown, calls: string[] = []): typeof globalThis.fetch {
+    return vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
+      const u = String(url)
+      const body =
+        typeof init.body === 'string'
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : undefined
+      if (body?.method) calls.push(body.method as string)
+      if (u.endsWith('/.well-known/ucp')) return jsonResponse(PROFILE)
+      if (body?.method === 'tools/list') {
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: { tools: [{ name: 'search_catalog', inputSchema }] },
+        })
+      }
+      return jsonResponse({ jsonrpc: '2.0', id: body?.id, result: { products: ['ok'] } })
+    }) as unknown as typeof globalThis.fetch
+  }
+
+  // Declares a dialect Ajv2020 doesn't know — schema content is fine, only
+  // meta-schema resolution fails. Stable trigger for the compile-failure
+  // branch without depending on a real production schema shape.
+  const UNCOMPILABLE_SCHEMA = {
+    $schema: 'https://json-schema.org/draft/9999-99/schema',
+    type: 'object',
+  }
+
+  // ── Happy path ─────────────────────────────────────────────────────────
+
+  it('compiles inputSchemas declaring JSON Schema draft 2020-12', async () => {
+    // SEARCH_SCHEMA at module top declares $schema: draft/2020-12. Any
+    // regression to a draft-07-only validator surfaces here as a focused
+    // failure instead of cascading across unrelated tests.
+    const result = await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: { catalog: { query: 'boots' } },
+      },
+      { cacheDir, agentRange: RANGE, fetch: buildFetch(SEARCH_SCHEMA), profileUrl: PROFILE_URL },
+    )
+    expect(result).toBeDefined()
+    // Happy path emits no validator-related verbose traces (the discover
+    // layer emits its own `discover:` lines; we assert on our own prefix).
+    expect(verboseLines.filter((l) => l.startsWith('[ucp] validate:'))).toEqual([])
+  })
+
+  // ── Soft signal: schema compile failure ────────────────────────────────
+
+  it('default mode: silently skips pre-flight when the schema cannot be compiled', async () => {
+    const calls: string[] = []
+    const result = await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: { catalog: { query: 'anything' } },
+      },
+      {
+        cacheDir,
+        agentRange: RANGE,
+        fetch: buildFetch(UNCOMPILABLE_SCHEMA, calls),
+        profileUrl: PROFILE_URL,
+      },
+    )
+    // Request reached the server; no local throw.
+    expect(calls).toContain('tools/call')
+    expect(result).toBeDefined()
+  })
+
+  it('verbose mode: emits a vlog trace explaining why validation was skipped', async () => {
+    await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: { catalog: { query: 'anything' } },
+      },
+      {
+        cacheDir,
+        agentRange: RANGE,
+        fetch: buildFetch(UNCOMPILABLE_SCHEMA),
+        profileUrl: PROFILE_URL,
+      },
+    )
+    const skipTrace = verboseLines.find((l) => l.includes('validate: skipped'))
+    expect(skipTrace).toBeDefined()
+    expect(skipTrace).toMatch(/"search_catalog"/)
+    expect(skipTrace).toMatch(/cannot compile published schema/)
+    expect(skipTrace).toMatch(/server will validate/)
+    // Trace attributes the failure to the client's validator, not the server.
+    expect(skipTrace).not.toMatch(/MCP_INVALID_RESPONSE/)
+    expect(skipTrace).not.toMatch(/business returned an invalid input schema/)
+  })
+
+  it('strict mode: throws MCP_INVALID_RESPONSE when the schema cannot be compiled', async () => {
+    process.env.UCP_STRICT_SCHEMA = '1'
+    let captured: unknown
+    await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: { catalog: { query: 'anything' } },
+      },
+      {
+        cacheDir,
+        agentRange: RANGE,
+        fetch: buildFetch(UNCOMPILABLE_SCHEMA),
+        profileUrl: PROFILE_URL,
+      },
+    ).catch((err) => {
+      captured = err
+    })
+    const err = captured as { code: string; layer: string } | undefined
+    expect(err?.code).toBe('MCP_INVALID_RESPONSE')
+    expect(err?.layer).toBe('transport')
+  })
+
+  // ── Soft signal: unknown plain field ──────────────────────────────────
+
+  it('default mode: silently allows plain keys not listed in the published schema', async () => {
+    // address_subdivision/address_postal_code are NOT in SEARCH_SCHEMA's
+    // context. Pre-2026-05 client policy threw SCHEMA_VALIDATION_FAILED
+    // before dispatch. New policy: defer to the server, which is
+    // authoritative on whether it accepts the field.
+    const calls: string[] = []
+    const result = await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: {
+          catalog: {
+            query: 'boots',
+            context: {
+              address_country: 'US',
+              address_subdivision: 'CA',
+              address_postal_code: '94105',
+            },
+          },
+        },
+      },
+      {
+        cacheDir,
+        agentRange: RANGE,
+        fetch: buildFetch(SEARCH_SCHEMA, calls),
+        profileUrl: PROFILE_URL,
+      },
+    )
+    expect(calls).toContain('tools/call')
+    expect(result).toBeDefined()
+  })
+
+  it('verbose mode: emits a vlog trace listing the plain keys the schema does not declare', async () => {
+    await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: {
+          catalog: {
+            query: 'boots',
+            context: { address_country: 'US', address_subdivision: 'CA' },
+          },
+        },
+      },
+      { cacheDir, agentRange: RANGE, fetch: buildFetch(SEARCH_SCHEMA), profileUrl: PROFILE_URL },
+    )
+    const flagTrace = verboseLines.find((l) => l.includes('not listed in published schema'))
+    expect(flagTrace).toBeDefined()
+    expect(flagTrace).toMatch(/"search_catalog"/)
+    expect(flagTrace).toMatch(/\/catalog\/context\/address_subdivision/)
+    expect(flagTrace).toMatch(/server will accept or reject/)
+  })
+
+  it('strict mode: throws SCHEMA_VALIDATION_FAILED for plain keys not in the schema', async () => {
+    process.env.UCP_STRICT_SCHEMA = '1'
+    let captured: unknown
+    await callOperation(
+      BUSINESS_URL,
+      {
+        capability: 'dev.ucp.shopping',
+        toolName: 'search_catalog',
+        input: {
+          catalog: {
+            query: 'boots',
+            context: { address_country: 'US', address_subdivision: 'CA' },
+          },
+        },
+      },
+      { cacheDir, agentRange: RANGE, fetch: buildFetch(SEARCH_SCHEMA), profileUrl: PROFILE_URL },
+    ).catch((err) => {
+      captured = err
+    })
+    const err = captured as
+      | { code: string; layer: string; context: { unknown_fields: string[] } }
+      | undefined
+    expect(err?.code).toBe('SCHEMA_VALIDATION_FAILED')
+    expect(err?.layer).toBe('client')
+    expect(err?.context.unknown_fields).toContain('/catalog/context/address_subdivision')
+  })
+
+  // ── Hard signal: payload mismatch (mode-invariant) ────────────────────
+
+  it('always throws SCHEMA_VALIDATION_FAILED when the payload fails a compiled schema', async () => {
+    // Hard signal: schema compiled fine, payload structurally wrong. Local
+    // fail-fast saves a server round-trip and gives clear typo feedback.
+    // No mode changes this — strict and default both throw here.
+    let captured: unknown
+    await callOperation(
+      BUSINESS_URL,
+      // Missing the required `catalog` field.
+      { capability: 'dev.ucp.shopping', toolName: 'search_catalog', input: {} },
+      { cacheDir, agentRange: RANGE, fetch: buildFetch(SEARCH_SCHEMA), profileUrl: PROFILE_URL },
+    ).catch((err) => {
+      captured = err
+    })
+    const err = captured as { code: string; layer: string } | undefined
+    expect(err?.code).toBe('SCHEMA_VALIDATION_FAILED')
+    expect(err?.layer).toBe('client')
+  })
+})
+
 describe('unwrapMcpCallResult — structuredContent vs content[].text', () => {
   // Catalog endpoints (catalog.shopify.com) return only structuredContent, no
   // content[].text fallback. Without this branch, every catalog response would
@@ -613,64 +803,5 @@ describe('unwrapMcpCallResult — structuredContent vs content[].text', () => {
   it('returns the input unchanged when content[].text is not valid JSON', () => {
     const wire = { content: [{ type: 'text', text: 'not-json{' }] }
     expect(unwrapMcpCallResult(wire)).toBe(wire)
-  })
-})
-
-describe('patchKnownUpstreamSchemaDefects — \\A anchor stopgap', () => {
-  it('rewrites a leading \\A to ^ at the root pattern', () => {
-    const out = patchKnownUpstreamSchemaDefects({ pattern: '\\Agid://shopify/p/' })
-    expect(out).toEqual({ pattern: '^gid://shopify/p/' })
-  })
-
-  it('rewrites nested patterns (the real catalog shape: properties → oneOf → items)', () => {
-    // Path that bites in production:
-    //   properties.catalog.properties.like.items.oneOf[0].properties.id.pattern
-    const input = {
-      type: 'object',
-      properties: {
-        catalog: {
-          type: 'object',
-          properties: {
-            like: {
-              type: 'array',
-              items: {
-                oneOf: [{ properties: { id: { type: 'string', pattern: '\\Agid://shopify/p/' } } }],
-              },
-            },
-          },
-        },
-      },
-    }
-    const out = patchKnownUpstreamSchemaDefects(input) as typeof input
-    const patched = out.properties.catalog.properties.like.items.oneOf[0]?.properties.id.pattern
-    expect(patched).toBe('^gid://shopify/p/')
-  })
-
-  it('does not mutate the input schema (deep clone)', () => {
-    const input = { pattern: '\\Agid://x' }
-    patchKnownUpstreamSchemaDefects(input)
-    expect(input.pattern).toBe('\\Agid://x')
-  })
-
-  it('leaves patterns without leading \\A untouched', () => {
-    const input = { pattern: '^already-anchored', other: { pattern: '[a-z]+' } }
-    expect(patchKnownUpstreamSchemaDefects(input)).toEqual(input)
-  })
-
-  it('ignores non-string pattern values (defensive)', () => {
-    // A misshapen schema where `pattern` is not a string shouldn't crash —
-    // AJV's own error path will surface the real defect.
-    const input = { pattern: 42 }
-    expect(patchKnownUpstreamSchemaDefects(input)).toEqual(input)
-  })
-
-  it('produces a regex AJV can compile under its default (u-flag) mode', async () => {
-    const { default: Ajv } = await import('ajv')
-    const ajv = new Ajv({ strict: false })
-    const patched = patchKnownUpstreamSchemaDefects({
-      type: 'string',
-      pattern: '\\Agid://shopify/p/',
-    })
-    expect(() => ajv.compile(patched as object)).not.toThrow()
   })
 })

--- a/src/core/operation.ts
+++ b/src/core/operation.ts
@@ -10,13 +10,18 @@
 
 import { randomUUID } from 'node:crypto'
 import type { AnySchema, ErrorObject } from 'ajv'
-import Ajv from 'ajv'
+// `Ajv2020` registers the JSON Schema draft 2020-12 meta-schema, which is
+// the dialect MCP servers declare in tool inputSchemas (MCP 2025-11-25 /
+// SEP-1613). Plain `Ajv` is draft-07-only and throws on the 2020-12 meta
+// URI before even looking at the schema content.
+import { Ajv2020 } from 'ajv/dist/2020.js'
 import addFormats from 'ajv-formats'
 
 import { ErrorCodes, UcpError } from '../lib/errors.js'
 import { omitUndefined } from '../lib/omit-undefined.js'
 import { type DiscoveredBusiness, type DiscoverOptions, discover } from './discover.js'
 import { mcpRpc } from './mcp-client.js'
+import { vlog } from './verbose.js'
 
 export type CallOperationCallerOptions = Pick<
   DiscoverOptions,
@@ -331,47 +336,24 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-// ════════════════════════════════════════════════════════════════════════════
-// TODO(upstream-fix): REMOVE THIS PATCHER AND ITS CALL SITE.
+// Pre-flight input validation is best-effort: the server is the authoritative
+// validator and will return SCHEMA_VALIDATION_FAILED for genuinely bad
+// payloads. The client signals it can give (compile failure, unknown plain
+// field) are uncertainty/policy preferences, not contract violations.
 //
-// Stopgap: rewrites leading `\A` start-of-string anchors to `^` in JSON Schema
-// `pattern` fields before AJV compilation.
+// Operating modes:
+//   default                  silent. Fast path for agents.
+//   --verbose / UCP_VERBOSE  emit `vlog()` traces so operators can diagnose.
+//   UCP_STRICT_SCHEMA=1      escalate soft signals to hard `UcpError` throws
+//                            (the pre-2026-05 behavior). Useful in CI and for
+//                            paranoid local development.
 //
-// Why this exists:
-//   `\A` is Ruby/PCRE syntax. JSON Schema (Draft 2020-12 §6.3.3) mandates
-//   ECMA-262 regex semantics, where `\A` is an invalid escape under the `u`
-//   flag (AJV's default). `catalog.shopify.com` ships `search_catalog.inputSchema`
-//   with `"pattern": "\\Agid://shopify/p/"`, so every JS/TS agent that
-//   AJV-compiles before dispatch errors out at the validation gate and never
-//   reaches the wire. We rewrite it client-side so global-catalog ops work
-//   during internal testing.
-//
-// Removal trigger:
-//   Upstream ships `^gid://shopify/p/` in search_catalog.inputSchema. Once fixed:
-//     1. Delete `patchKnownUpstreamSchemaDefects` + `walkPatternFields`.
-//     2. Drop the call in `validateOperationInput`.
-//     3. Drop the matching test in `operation.test.ts`.
-//     4. Flip `test/integration/catalog-live.integration.test.ts` to
-//        require `status:'ok'` (remove `MCP_INVALID_RESPONSE` from
-//        `KNOWN_UPSTREAM_ERRORS`).
-// ════════════════════════════════════════════════════════════════════════════
-export function patchKnownUpstreamSchemaDefects(schema: unknown): unknown {
-  if (typeof schema !== 'object' || schema === null) return schema
-  const cloned: unknown = structuredClone(schema)
-  walkPatternFields(cloned)
-  return cloned
-}
-
-function walkPatternFields(node: unknown): void {
-  if (Array.isArray(node)) {
-    for (const item of node) walkPatternFields(item)
-    return
-  }
-  if (!isPlainObject(node)) return
-  if (typeof node.pattern === 'string' && node.pattern.startsWith('\\A')) {
-    node.pattern = `^${node.pattern.slice(2)}`
-  }
-  for (const value of Object.values(node)) walkPatternFields(value)
+// Payload validation against a successfully compiled schema is NOT a soft
+// signal: it stays a hard throw in every mode — typos benefit from a fast
+// local failure rather than a round-trip to the server.
+function strictSchemaMode(): boolean {
+  const v = process.env.UCP_STRICT_SCHEMA
+  return v === '1' || v === 'true'
 }
 
 function validateOperationInput(opts: {
@@ -381,35 +363,38 @@ function validateOperationInput(opts: {
   schema: unknown
   args: Record<string, unknown>
 }): void {
-  const ajv = new Ajv({ allErrors: true, strict: false })
+  const ajv = new Ajv2020({ allErrors: true, strict: false })
   addFormats(ajv)
 
-  // TODO(upstream-fix): drop this patcher call once catalog.shopify.com
-  // fixes `\A` → `^`. See banner above `patchKnownUpstreamSchemaDefects`.
-  const schema = patchKnownUpstreamSchemaDefects(opts.schema)
-  rejectUnknownPlainFields({
+  flagUnknownPlainFields({
     business: opts.business,
     capability: opts.capability,
     toolName: opts.toolName,
-    schema,
+    schema: opts.schema,
     args: opts.args,
   })
   let validate: ReturnType<typeof ajv.compile>
   try {
-    validate = ajv.compile(schema as AnySchema)
+    validate = ajv.compile(opts.schema as AnySchema)
   } catch (err) {
-    throw new UcpError({
-      layer: 'transport',
-      code: ErrorCodes.MCP_INVALID_RESPONSE,
-      message: `business returned an invalid input schema for "${opts.toolName}"`,
-      cause: err as Error,
-      context: {
-        business: opts.business,
-        capability: opts.capability,
-        tool: opts.toolName,
-        schema: opts.schema,
-      },
-    })
+    if (strictSchemaMode()) {
+      throw new UcpError({
+        layer: 'transport',
+        code: ErrorCodes.MCP_INVALID_RESPONSE,
+        message: `business returned an invalid input schema for "${opts.toolName}"`,
+        cause: err as Error,
+        context: {
+          business: opts.business,
+          capability: opts.capability,
+          tool: opts.toolName,
+          schema: opts.schema,
+        },
+      })
+    }
+    vlog(
+      `validate: skipped "${opts.toolName}" — cannot compile published schema (${(err as Error).message}); server will validate`,
+    )
+    return
   }
 
   if (validate(opts.args)) return
@@ -435,7 +420,13 @@ function validateOperationInput(opts: {
   })
 }
 
-function rejectUnknownPlainFields(opts: {
+// Plain-field policy is a client opinion, not a contract gate. The server
+// owns the actual accept/reject decision — if it accepts a field we flagged,
+// the agent gets a successful response and we were wrong to nag. Default
+// behavior surfaces the policy via `--verbose` (operators debugging payload
+// shape see what got flagged) and lets the request through.
+// `UCP_STRICT_SCHEMA=1` restores the throw for CI / paranoid local use.
+function flagUnknownPlainFields(opts: {
   business: string
   capability: string
   toolName: string
@@ -445,19 +436,24 @@ function rejectUnknownPlainFields(opts: {
   const unknown = findUnknownPlainFields(opts.schema, opts.args, '')
   if (unknown.length === 0) return
 
-  throw new UcpError({
-    layer: 'client',
-    code: ErrorCodes.SCHEMA_VALIDATION_FAILED,
-    message: `operation input contains unknown field${unknown.length === 1 ? '' : 's'} for "${opts.toolName}": ${formatUnknownFields(unknown)}. The business's advertised input schema does not list this field, and per client policy only listed fields plus reverse-DNS extension keys are sent (some canonical UCP fields are still spec-valid but require explicit business support). Run \`<op> --input-schema\` to see what this business actually accepts.`,
-    context: {
-      business: opts.business,
-      capability: opts.capability,
-      tool: opts.toolName,
-      unknown_fields: unknown,
-      input: opts.args,
-      schema: opts.schema,
-    },
-  })
+  if (strictSchemaMode()) {
+    throw new UcpError({
+      layer: 'client',
+      code: ErrorCodes.SCHEMA_VALIDATION_FAILED,
+      message: `operation input contains unknown field${unknown.length === 1 ? '' : 's'} for "${opts.toolName}": ${formatUnknownFields(unknown)}. The business's advertised input schema does not list this field, and per client policy only listed fields plus reverse-DNS extension keys are sent (some canonical UCP fields are still spec-valid but require explicit business support). Run \`<op> --input-schema\` to see what this business actually accepts.`,
+      context: {
+        business: opts.business,
+        capability: opts.capability,
+        tool: opts.toolName,
+        unknown_fields: unknown,
+        input: opts.args,
+        schema: opts.schema,
+      },
+    })
+  }
+  vlog(
+    `validate: "${opts.toolName}" carries field${unknown.length === 1 ? '' : 's'} not listed in published schema: ${formatUnknownFields(unknown)} (server will accept or reject)`,
+  )
 }
 
 function formatUnknownFields(fields: string[]): string {

--- a/test/integration/catalog-live.integration.test.ts
+++ b/test/integration/catalog-live.integration.test.ts
@@ -60,37 +60,19 @@ describe.skipIf(!LIVE)('live: Shopify global catalog (UCP_LIVE_TESTS=1)', () => 
     expect(init.code).toBe(0)
 
     const search = await run(env, ['catalog', 'search', '--set', '/query=trail map'])
-    // What "working" means here is: the catalog-fallback rung dispatched to
-    // the live endpoint and we got a structured UCP envelope back. Success
-    // (dispatch identity + `result` present) is the happy path; certain
-    // upstream errors are known and not test failures (see
-    // KNOWN_UPSTREAM_ERRORS below). Anything outside that allowlist fails
-    // loudly with full context so a regression explains itself instead of
-    // just blaming the assertion.
+    // Working means: catalog-fallback rung dispatched to the live endpoint
+    // and returned a structured UCP envelope with dispatch identity
+    // (`business`) and the catalog payload (`result`). The previous
+    // MCP_INVALID_RESPONSE tolerance is gone: schema-dialect mismatches and
+    // Ruby-flavor regex defects are now handled client-side by
+    // validateOperationInput's soft-fail path, so a failure here is a real
+    // regression.
     const body = JSON.parse(search.stdout) as Record<string, unknown>
     expect(body).toBeTypeOf('object')
-
-    // As of 2026-05-10 the live endpoint publishes an `inputSchema` for
-    // search_catalog containing a Ruby/PCRE-style regex (`\Agid://shopify/p/`)
-    // that AJV/ECMAScript rejects. Captured here so the test stays green while
-    // we track the upstream fix; flip back to a hard requirement once the
-    // catalog team ships a valid schema.
-    const KNOWN_UPSTREAM_ERRORS = new Set([
-      'MCP_INVALID_RESPONSE', // schema regex incompat — see SCHEMA_REGEX_INCOMPAT_2026_05_10
-    ])
-
-    if (typeof body.business === 'string') {
-      // Success path: dispatch identity at root + `result` carries the
-      // catalog payload. No envelope-level `status` field anymore — the
-      // presence of `business`/`result` is the success discriminator.
-      expect(body.result).toBeDefined()
-      expect(body).toHaveProperty('cta')
-    } else if (typeof body.code === 'string' && KNOWN_UPSTREAM_ERRORS.has(body.code)) {
-      // Tolerated upstream defect; ensure the error envelope itself is
-      // well-formed so we'd catch a regression in *our* error path.
-      expect(body).toHaveProperty('message')
-    } else {
+    if (typeof body.business !== 'string') {
       expect.fail(`unexpected live response: ${search.stdout}\nstderr: ${search.stderr}`)
     }
+    expect(body.result).toBeDefined()
+    expect(body).toHaveProperty('cta')
   }, 30_000)
 })


### PR DESCRIPTION
Swap the validator to `Ajv2020` and reframe client-side pre-flight validation as best-effort: the server is the authoritative validator, so client-side uncertainty (can't compile the schema) and client-side opinions (payload carries a plain key not listed in the schema) no longer block dispatch.

Agents and scripts that previously branched on `MCP_INVALID_RESPONSE` from this code path will no longer see it in default mode. Set `UCP_STRICT_SCHEMA=1` to restore strict behavior.