### PR TITLE
fix: point default profile URL at shopify.dev

### DIFF
--- a/.changeset/default-profile-url-shopify-dev.md
+++ b/.changeset/default-profile-url-shopify-dev.md
@@ -1,0 +1,7 @@
+---
+"@shopify/ucp-cli": patch
+---
+
+Point the baked-in default agent profile URL at the canonical shopify.dev
+version (`/ucp/agent-profiles/2026-04-08/valid-with-capabilities.json`).
+

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "specBaseUrl": "https://ucp.dev",
     "protocolMin": "2026-01-23",
     "protocolMax": "2026-04-08",
-    "default_profile_url_template": "https://www.igvita.com/ucp/profile.json",
+    "default_profile_url_template": "https://shopify.dev/ucp/agent-profiles/2026-04-08/valid-with-capabilities.json",
     "default_catalog_url": "https://catalog.shopify.com"
   }
 }


### PR DESCRIPTION
Verified end-to-end against catalog.shopify.com and a storefront UCP endpoint (read + write ops both return 200) with the swapped URL baked into dist/bin.js. Both URLs satisfy 2026-04-08 server-side profile validation (top-level services + payment_handlers as Hash, Content-Type: application/json, Cache-Control: public + max-age >= 60).