### PR TITLE
feat: honor standard proxy environment variables

### DIFF
--- a/.changeset/proxy-env-support.md
+++ b/.changeset/proxy-env-support.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ucp-cli': minor
+---
+
+Honor standard proxy environment variables. When `HTTPS_PROXY`/`https_proxy`/`HTTP_PROXY`/`http_proxy` is set, the CLI routes requests through the proxy (respecting `NO_PROXY`) instead of silently ignoring it and stalling until the request timeout. Adds a `proxy` check to `ucp doctor`, a `--verbose` trace line, and names the proxy in transport, HTTP, and invalid-body error messages so a proxy failure can't be misread as an unreachable merchant. Credentials are redacted everywhere. Implemented via undici's `EnvHttpProxyAgent`, loaded only when a proxy variable is set.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,22 @@ There is no `--auth-bearer` flag and no `UCP_AUTH_BEARER` env var. `--header` is
 | `UCP_HOME` | Override the local state directory (default `~/.ucp`) |
 | `UCP_VERBOSE` | Set `1`/`true` to print trace lines to stderr |
 | `UCP_STRICT_SCHEMA` | Set `1`/`true` to make client-side input validation fail-closed: throw `MCP_INVALID_RESPONSE` when the published input schema can't be compiled, and `SCHEMA_VALIDATION_FAILED` when a payload carries plain keys not listed in the schema. Default is silent + dispatch (the server is the authoritative validator); `--verbose` surfaces these as traces. |
+| `HTTPS_PROXY` / `HTTP_PROXY` | Route outbound requests through a proxy. Honored automatically — see [Proxies and TLS inspection](#proxies-and-tls-inspection). Lowercase variants work too. |
+| `NO_PROXY` | Hosts to reach directly, bypassing the proxy. Comma-separated; leading dots, wildcards, and ports supported — CIDR blocks are not. |
+| `NODE_EXTRA_CA_CERTS` | Path to a PEM bundle of extra trusted CAs, for TLS-inspecting proxies. Handled by Node itself, *appended* to the built-in trust store. |
+
+### Proxies and TLS inspection
+
+If `HTTPS_PROXY` (or `https_proxy`) is set, `ucp` routes through it automatically — no flag, no config, same environment contract as curl, git, and pip:
+
+```sh
+export HTTPS_PROXY=http://proxy.corp.example:3128
+export NO_PROXY=.internal.example,localhost
+ucp doctor          # `proxy` check: what was picked up (credentials redacted); fails if the value is unusable
+ucp --verbose ...   # `[ucp] proxy: ...` trace line on stderr
+```
+
+Behind a TLS-inspecting proxy (Zscaler, CrowdStrike, BlueCoat), trust its root CA the standard Node way: point `NODE_EXTRA_CA_CERTS` at the PEM file, or install it in the OS store and set `NODE_USE_SYSTEM_CA=1` (Node ≥ 22.19 / ≥ 24.6). Divergences from curl, should you hit them: `ALL_PROXY` is not read, `NO_PROXY` matches names rather than CIDR blocks, the proxy URL must include its scheme, and `socks5://` is untested. Anything else — a proxy that is down, misconfigured, blocking, or serving a sign-in page — shows up named in the error message and in `ucp doctor`, not as a silent stall.
 
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@jmespath-community/jmespath": "^1.3.0",
     "incur": "^0.4.10",
+    "undici": "^7.29.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       incur:
         specifier: ^0.4.10
         version: 0.4.10
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1460,6 +1463,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==, tarball: https://registry.npmjs.org/undici/-/undici-7.29.0.tgz}
+    engines: {node: '>=20.18.1'}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==, tarball: https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz}
     engines: {node: '>= 4.0.0'}
@@ -2803,6 +2810,8 @@ snapshots:
   ufo@1.6.4: {}
 
   undici-types@8.3.0: {}
+
+  undici@7.29.0: {}
 
   universalify@0.1.2: {}
 

--- a/scripts/defines.mjs
+++ b/scripts/defines.mjs
@@ -32,5 +32,9 @@ export function buildDefines() {
     __DEFAULT_CATALOG_URL__: JSON.stringify(pkg.ucp.default_catalog_url),
     __PROTOCOL_MIN__: JSON.stringify(pkg.ucp.protocolMin),
     __PROTOCOL_MAX__: JSON.stringify(pkg.ucp.protocolMax),
+    // Major-version floor parsed from engines. npm only *warns* on engines at
+    // install time, so the CLI checks this itself (doctor `runtime` check,
+    // proxy load-failure hint) — package.json stays the single source.
+    __MIN_NODE_MAJOR__: JSON.stringify(Number(pkg.engines.node.match(/\d+/)[0])),
   }
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,15 @@
 import { runUcpCli } from './cli.js'
+import { installProxyDispatcher } from './core/proxy.js'
 
 // Keep the package executable as a tiny unconditional entrypoint. The CLI
 // factory lives in cli.ts for tests/imports; this module is only reached through
 // package.json#bin, so it must not use an import.meta/process.argv[1] guard.
+
+// The proxy dispatcher must be installed from this entrypoint only (see
+// core/proxy.ts for why Node needs it at all): in cli.ts it would mutate the
+// process-global dispatcher for every test that imports runUcpCli; in
+// index.ts it would break the "sideEffects": false contract for library
+// consumers. Awaited so no request can start on the direct dispatcher; free
+// when no proxy is configured (undici is not even imported).
+await installProxyDispatcher()
 await runUcpCli()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import {
 import { canonicalizeOrigin, type HeaderMap, resolveHeaders } from './core/headers.js'
 import { isDryRunPreview } from './core/operation.js'
 import { DEFAULT_AGENT_CAPABILITY_IDS } from './core/profile.js'
+import { describeProxyState } from './core/proxy.js'
 import { acceptsHttpsUrl, parseHttpsUrl } from './core/url.js'
 import { setVerboseWriter, vlog } from './core/verbose.js'
 import { ErrorCodes, UcpError } from './lib/errors.js'
@@ -1223,6 +1224,10 @@ export async function runUcpCli(argv = process.argv.slice(2)): Promise<void> {
       process.stderr.write(msg)
     })
   }
+  // The proxy decision is made in bin.ts before the verbose writer exists,
+  // so it is traced here instead. It leads the trace because "are we proxying
+  // at all" is the first question when debugging a corporate-network stall.
+  vlog(`proxy: ${describeProxyState()}`)
   const serveArgv = argv.filter((a) => a !== '--verbose')
   // Intercept `ucp skills add` so we can prune incur's auto-generated
   // per-command sub-skills after the sync. Help, list, and bare `skills`

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PlatformProfile } from '../core/profile.js'
 import { saveUserProfile, writeActive } from '../core/profile-store.js'
+import { installProxyDispatcher, resetProxyStateForTests } from '../core/proxy.js'
+import { clearProxyEnv } from '../test-utils.js'
 import { runDoctor } from './doctor.js'
 
 const SAMPLE_BODY: PlatformProfile = {
@@ -192,5 +194,45 @@ describe('runDoctor — network probe', () => {
   it('skipNetwork omits the profile-url check', async () => {
     const result = await runDoctor({ homeDir, skipNetwork: true, env: {} })
     expect(result.checks.find((c) => c.id === 'profile-url')).toBeUndefined()
+  })
+})
+
+describe('runDoctor — proxy check', () => {
+  let homeDir: string
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'ucp-cli-doctor-test-'))
+    clearProxyEnv(vi.stubEnv)
+  })
+  afterEach(async () => {
+    await rm(homeDir, { recursive: true, force: true })
+    vi.unstubAllEnvs()
+    resetProxyStateForTests()
+  })
+
+  it('reports direct connections when no proxy env is set', async () => {
+    await installProxyDispatcher()
+    const result = await runDoctor({ homeDir, skipNetwork: true, env: {} })
+    expect(findCheck(result, 'proxy').status).toBe('ok')
+    expect(findCheck(result, 'proxy').detail).toBe('none configured; connecting directly')
+  })
+
+  it('reports the active proxy without leaking credentials', async () => {
+    vi.stubEnv('https_proxy', 'http://alice:s3cret@proxy.example:3128')
+    await installProxyDispatcher()
+    const check = findCheck(await runDoctor({ homeDir, skipNetwork: true, env: {} }), 'proxy')
+    expect(check.status).toBe('ok')
+    expect(check.detail).toContain('proxy.example:3128')
+    expect(check.detail).not.toContain('s3cret')
+  })
+
+  it('fails when proxy env is present but the dispatcher could not be installed', async () => {
+    // The state that is otherwise invisible: requests silently go direct and
+    // time out, which reads as an unreachable merchant.
+    vi.stubEnv('https_proxy', 'not-a-url')
+    await installProxyDispatcher()
+    const check = findCheck(await runDoctor({ homeDir, skipNetwork: true, env: {} }), 'proxy')
+    expect(check.status).toBe('fail')
+    expect(check.detail).toContain('Invalid URL')
   })
 })

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -210,6 +210,32 @@ describe('runDoctor — proxy check', () => {
     resetProxyStateForTests()
   })
 
+  it('reports the running Node version as a passing runtime check', async () => {
+    const result = await runDoctor({ homeDir, skipNetwork: true, env: {} })
+    const check = findCheck(result, 'runtime')
+    expect(check.status).toBe('ok')
+    expect(check.detail).toBe(`Node v${process.versions.node}`)
+  })
+
+  it('fails the runtime check below the engines floor', async () => {
+    // npm engines is warning-only, so an unsupported Node still installs and
+    // mostly runs; doctor is where that state gets caught deliberately
+    // instead of as a cryptic dependency error (field-reported: undici 7 on
+    // Node 18 dies with "File is not defined").
+    const descriptor = Object.getOwnPropertyDescriptor(process.versions, 'node')
+    Object.defineProperty(process.versions, 'node', { ...descriptor, value: '18.19.1' })
+    try {
+      const result = await runDoctor({ homeDir, skipNetwork: true, env: {} })
+      const check = findCheck(result, 'runtime')
+      expect(check.status).toBe('fail')
+      expect(check.detail).toContain('Node v18.19.1')
+      expect(check.detail).toContain('requires Node >= 22')
+      expect(result.ok).toBe(false)
+    } finally {
+      Object.defineProperty(process.versions, 'node', descriptor as PropertyDescriptor)
+    }
+  })
+
   it('reports direct connections when no proxy env is set', async () => {
     await installProxyDispatcher()
     const result = await runDoctor({ homeDir, skipNetwork: true, env: {} })

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,6 +23,7 @@ import {
   readActive,
   readUserProfile,
 } from '../core/profile-store.js'
+import { describeProxyState, proxyState } from '../core/proxy.js'
 
 export interface DoctorDeps {
   homeDir?: string
@@ -74,7 +75,14 @@ export async function runDoctor(deps: DoctorDeps = {}): Promise<DoctorResult> {
   const profileName = env.UCP_PROFILE ?? active.profile
   checks.push(await checkProfile(profileName, storeOpts))
 
-  // 4. Profile hosting URL reachable. HEAD is best-effort: warn (not fail) on
+  // 4. Outbound network configuration. Reports the proxy decision made at
+  // boot, catching the otherwise-invisible state: proxy env present but
+  // unusable, which looks exactly like an unreachable merchant. Ordered
+  // before the network probe so a proxy misconfiguration reads as the cause
+  // of the probe's failure.
+  checks.push(checkProxy())
+
+  // 5. Profile hosting URL reachable. HEAD is best-effort: warn (not fail) on
   // failure since a missing-yet-managed profile URL is a legitimate intermediate state
   // and a network blip shouldn't fail `doctor` for a perfectly valid setup.
   if (deps.skipNetwork !== true) {
@@ -83,6 +91,17 @@ export async function runDoctor(deps: DoctorDeps = {}): Promise<DoctorResult> {
 
   const ok = checks.every((c) => c.status !== 'fail')
   return { ok, checks }
+}
+
+// Proxy env we could not act on is a `fail`: every outbound request silently
+// bypasses the proxy and times out, a broken install even though nothing
+// local is wrong. `inactive` is the common, healthy path.
+function checkProxy(): Check {
+  return {
+    id: 'proxy',
+    status: proxyState().status === 'error' ? 'fail' : 'ok',
+    detail: describeProxyState(),
+  }
 }
 
 async function checkWritable(id: string, path: string): Promise<Check> {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -55,7 +55,13 @@ export async function runDoctor(deps: DoctorDeps = {}): Promise<DoctorResult> {
   const storeOpts: ProfileStoreOptions = deps.homeDir !== undefined ? { homeDir: deps.homeDir } : {}
   const checks: Check[] = []
 
-  // 1. ~/.ucp home + cache + profiles dirs writable. Side-effect: mkdir
+  // 1. Supported runtime. npm `engines` is warning-only at install time, so
+  // an out-of-contract Node still installs and mostly runs — until a
+  // dependency trips over a missing global with a cryptic error. Checked
+  // first because it explains every downstream failure.
+  checks.push(checkRuntime())
+
+  // 2. ~/.ucp home + cache + profiles dirs writable. Side-effect: mkdir
   // recursive so a clean install passes (matches what readActive/saveUserProfile
   // do on first write). Failure here means the rest of the CLI is broken too.
   const home = profileStoreHome(storeOpts)
@@ -63,26 +69,26 @@ export async function runDoctor(deps: DoctorDeps = {}): Promise<DoctorResult> {
   checks.push(await checkWritable('profiles-dir', profilesRoot(storeOpts)))
   checks.push(await checkWritable('cache-dir', join(home, 'cache')))
 
-  // 2. active.yaml resolves (degraded-empty allowed; readActive never throws).
+  // 3. active.yaml resolves (degraded-empty allowed; readActive never throws).
   // The check exists so a corrupt file shows up explicitly rather than silently
   // collapsing the session to defaults.
   const activeCheck = await checkActive(storeOpts)
   checks.push(activeCheck)
 
-  // 3. Active local profile parses from disk. Profile init is required; there
+  // 4. Active local profile parses from disk. Profile init is required; there
   // is no synthetic runtime profile for operations.
   const active = await readActive(storeOpts)
   const profileName = env.UCP_PROFILE ?? active.profile
   checks.push(await checkProfile(profileName, storeOpts))
 
-  // 4. Outbound network configuration. Reports the proxy decision made at
+  // 5. Outbound network configuration. Reports the proxy decision made at
   // boot, catching the otherwise-invisible state: proxy env present but
   // unusable, which looks exactly like an unreachable merchant. Ordered
   // before the network probe so a proxy misconfiguration reads as the cause
   // of the probe's failure.
   checks.push(checkProxy())
 
-  // 5. Profile hosting URL reachable. HEAD is best-effort: warn (not fail) on
+  // 6. Profile hosting URL reachable. HEAD is best-effort: warn (not fail) on
   // failure since a missing-yet-managed profile URL is a legitimate intermediate state
   // and a network blip shouldn't fail `doctor` for a perfectly valid setup.
   if (deps.skipNetwork !== true) {
@@ -91,6 +97,22 @@ export async function runDoctor(deps: DoctorDeps = {}): Promise<DoctorResult> {
 
   const ok = checks.every((c) => c.status !== 'fail')
   return { ok, checks }
+}
+
+// Below the engines floor is a `fail`, not a warn: the contract is declared,
+// the runtime is EOL, and breakage arrives as cryptic dependency errors (on
+// Node 18 the proxy dispatcher dies with "File is not defined"). A CI gate
+// going red on an unsupported runtime is the check working as intended.
+function checkRuntime(): Check {
+  const version = process.versions.node
+  const supported = Number(version.split('.', 1)[0]) >= __MIN_NODE_MAJOR__
+  return {
+    id: 'runtime',
+    status: supported ? 'ok' : 'fail',
+    detail: supported
+      ? `Node v${version}`
+      : `Node v${version} — ucp requires Node >= ${__MIN_NODE_MAJOR__}`,
+  }
 }
 
 // Proxy env we could not act on is a `fail`: every outbound request silently

--- a/src/core/cache.test.ts
+++ b/src/core/cache.test.ts
@@ -11,6 +11,7 @@ import { z } from 'incur'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UcpError } from '../lib/errors.js'
+import { clearProxyEnv } from '../test-utils.js'
 import {
   type CacheEntry,
   cacheCompute,
@@ -20,6 +21,7 @@ import {
   parseMaxAge,
   ucpHomeDir,
 } from './cache.js'
+import { installProxyDispatcher, resetProxyStateForTests } from './proxy.js'
 
 describe('originToFilename', () => {
   it.each([
@@ -384,5 +386,96 @@ describe('cacheCompute', () => {
       () => false,
     )
     expect(exists).toBe(false)
+  })
+})
+
+// The message is the only field incur's error envelope surfaces (it emits
+// {code, message, retryable} and drops `context`), so a configured proxy has
+// to be named there. Profile discovery is the first network call in any flow,
+// which makes this the most likely place a proxy failure shows up — and
+// without the annotation it is indistinguishable from a dead merchant.
+describe('fetchCached — proxy annotation on transport failure', () => {
+  let cacheDir: string
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'ucp-cli-cache-proxy-test-'))
+    clearProxyEnv(vi.stubEnv)
+  })
+
+  afterEach(async () => {
+    await rm(cacheDir, { recursive: true, force: true })
+    vi.unstubAllEnvs()
+    resetProxyStateForTests()
+  })
+
+  const rejectingFetch = () =>
+    vi.fn(async () => {
+      throw new Error('network down')
+    }) as unknown as typeof globalThis.fetch
+
+  it('names the proxy in the message when one is configured', async () => {
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    await installProxyDispatcher()
+    await expect(
+      fetchCached('https://example.com/x', {
+        cacheDir,
+        errorCodes: codes,
+        fetch: rejectingFetch(),
+      }),
+    ).rejects.toMatchObject({
+      code: 'TEST_FETCH_FAILED',
+      message: expect.stringContaining('proxy: enabled'),
+      retryable: true,
+    })
+  })
+
+  it('annotates a filtering-proxy block page returned as an HTTP error', async () => {
+    // Zscaler/Squid answer on the merchant's behalf with their own 403. The
+    // status is the proxy's, so attributing it to the merchant is a misread.
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    await installProxyDispatcher()
+    const blocked = vi.fn(
+      async () => new Response('<html>blocked by policy</html>', { status: 403 }),
+    ) as unknown as typeof globalThis.fetch
+    await expect(
+      fetchCached('https://example.com/x', { cacheDir, errorCodes: codes, fetch: blocked }),
+    ).rejects.toMatchObject({
+      code: 'TEST_FETCH_FAILED',
+      message: expect.stringContaining('proxy: enabled'),
+    })
+  })
+
+  it('annotates a captive-portal HTML page served with HTTP 200', async () => {
+    // The likeliest symptom of all, and the one that looks least like a proxy
+    // problem: 200 OK, bytes on the wire, HTML where JSON was expected.
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    await installProxyDispatcher()
+    const captive = vi.fn(
+      async () =>
+        new Response('<html>sign in to continue</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+    ) as unknown as typeof globalThis.fetch
+    await expect(
+      fetchCached('https://example.com/x', { cacheDir, errorCodes: codes, fetch: captive }),
+    ).rejects.toMatchObject({
+      code: 'TEST_INVALID_JSON',
+      message: expect.stringContaining('proxy: enabled'),
+    })
+  })
+
+  it('adds nothing to the message when no proxy is configured', async () => {
+    await installProxyDispatcher()
+    await expect(
+      fetchCached('https://example.com/x', {
+        cacheDir,
+        errorCodes: codes,
+        fetch: rejectingFetch(),
+      }),
+    ).rejects.toMatchObject({
+      code: 'TEST_FETCH_FAILED',
+      message: expect.not.stringContaining('proxy'),
+    })
   })
 })

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -22,6 +22,7 @@ import { type ErrorCode, UcpError } from '../lib/errors.js'
 import type { ErrorLayer } from '../lib/types.js'
 import { formatZodIssues } from '../lib/zod-format.js'
 import { ucpFetch } from './http-client.js'
+import { proxyErrorContext, proxyErrorNote } from './proxy.js'
 import { vlog } from './verbose.js'
 
 /**
@@ -183,20 +184,29 @@ export async function fetchCached<T = unknown>(
       traceLabel: 'cache',
     })
   } catch (err) {
+    // Profile discovery is the first network call in every flow, so it is where
+    // an ignored or broken proxy surfaces first. Annotate so the envelope can't
+    // be misread as "merchant unreachable". Absent entirely when no proxy is
+    // configured. See core/proxy.ts.
+    const proxy = proxyErrorContext()
     throw new UcpError({
       layer,
       code: options.errorCodes.fetchFailed,
-      message: `fetch failed: request to ${url} could not be completed`,
+      message: `fetch failed: request to ${url} could not be completed${proxyErrorNote()}`,
       cause: err as Error,
       retryable: true,
+      ...(proxy !== undefined && { context: proxy }),
     })
   }
 
   if (!response.ok) {
+    // A filtering proxy answers on the merchant's behalf: Zscaler and Squid
+    // return their own 403 policy page. Without the annotation that reads as
+    // "the merchant rejected us", and the operator debugs the wrong system.
     throw new UcpError({
       layer,
       code: options.errorCodes.fetchFailed,
-      message: `fetch failed: HTTP ${response.status} from ${url}`,
+      message: `fetch failed: HTTP ${response.status} from ${url}${proxyErrorNote()}`,
       http_status: response.status,
       retryable: response.status >= 500,
     })
@@ -206,10 +216,14 @@ export async function fetchCached<T = unknown>(
   try {
     raw = await response.json()
   } catch (err) {
+    // The highest-probability proxy symptom of all: a TLS-inspecting or
+    // captive proxy serves an HTML sign-in or block page with HTTP 200, and
+    // JSON parsing is where it lands. "Bytes came back" does not mean the
+    // merchant answered — it means *something* answered.
     throw new UcpError({
       layer,
       code: options.errorCodes.invalidJson,
-      message: `response body is not valid JSON: ${url}`,
+      message: `response body is not valid JSON: ${url}${proxyErrorNote()}`,
       cause: err as Error,
     })
   }

--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -4,9 +4,10 @@
 // what JSON-RPC request we send and how the narrow MCP adapter maps the
 // response or failure into UCP errors.
 
-import { describe, expect, it, vi } from 'vitest'
-
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearProxyEnv } from '../test-utils.js'
 import { mcpRpc } from './mcp-client.js'
+import { installProxyDispatcher, resetProxyStateForTests } from './proxy.js'
 
 const ENDPOINT = 'https://shop.example.invalid/ucp/mcp'
 
@@ -325,5 +326,57 @@ describe('mcpRpc — error mapping', () => {
     ).rejects.toThrowError(
       expect.objectContaining({ code: 'INVALID_INPUT', layer: 'client' }) as unknown as Error,
     )
+  })
+})
+
+// Transport failures must name a configured proxy in the MESSAGE: incur's
+// error envelope is {code, message, retryable} and drops `context`, so this is
+// the only channel a human or agent actually reads. Without it, "the proxy
+// refused us" and "the merchant is down" look identical.
+describe('mcpRpc — proxy annotation on transport failures', () => {
+  beforeEach(() => {
+    clearProxyEnv(vi.stubEnv)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    resetProxyStateForTests()
+  })
+
+  const rejectingFetch = () =>
+    vi.fn(async () => {
+      throw new Error('ECONNREFUSED')
+    }) as unknown as typeof globalThis.fetch
+
+  it('names the proxy in the message when one is configured', async () => {
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    await installProxyDispatcher()
+    await expect(
+      mcpRpc({ endpoint: ENDPOINT, method: 'tools/list', fetch: rejectingFetch() }),
+    ).rejects.toMatchObject({
+      code: 'TRANSPORT_NETWORK_ERROR',
+      message: expect.stringContaining('proxy: enabled'),
+    })
+  })
+
+  it('flags a failed proxy install as the reason requests went direct', async () => {
+    vi.stubEnv('https_proxy', 'not-a-url')
+    await installProxyDispatcher()
+    await expect(
+      mcpRpc({ endpoint: ENDPOINT, method: 'tools/list', fetch: rejectingFetch() }),
+    ).rejects.toMatchObject({
+      code: 'TRANSPORT_NETWORK_ERROR',
+      message: expect.stringContaining('set but unusable'),
+    })
+  })
+
+  it('adds nothing to the message when no proxy is configured', async () => {
+    await installProxyDispatcher()
+    await expect(
+      mcpRpc({ endpoint: ENDPOINT, method: 'tools/list', fetch: rejectingFetch() }),
+    ).rejects.toMatchObject({
+      code: 'TRANSPORT_NETWORK_ERROR',
+      message: expect.not.stringContaining('proxy'),
+    })
   })
 })

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -15,6 +15,7 @@
 import { ErrorCodes, UcpError } from '../lib/errors.js'
 import type { CtaBlock } from '../lib/types.js'
 import { ucpFetch } from './http-client.js'
+import { proxyErrorContext, proxyErrorNote } from './proxy.js'
 import { parseHttpsUrl } from './url.js'
 import { vlog } from './verbose.js'
 
@@ -102,9 +103,13 @@ export async function mcpRpc<T = unknown>(opts: McpRpcOptions): Promise<T> {
     throw new UcpError({
       layer: 'transport',
       code: ErrorCodes.TRANSPORT_NETWORK_ERROR,
-      message: `MCP request to ${endpoint} failed: ${(err as Error).message}`,
+      message: `MCP request to ${endpoint} failed: ${(err as Error).message}${proxyErrorNote()}`,
       cause: err as Error,
-      context: { endpoint, method: opts.method },
+      // An ignored or broken proxy is indistinguishable from an unreachable
+      // merchant at this layer, and an agent reading this envelope would
+      // otherwise report "merchant is down". Spreads to nothing when no proxy
+      // is configured.
+      context: { endpoint, method: opts.method, ...proxyErrorContext() },
     })
   }
 
@@ -124,12 +129,16 @@ export async function mcpRpc<T = unknown>(opts: McpRpcOptions): Promise<T> {
         body: { raw_body: truncate(responseText) },
       })
     }
+    // Annotated for the same reason as the transport failure above, even
+    // though bytes came back: a captive or TLS-inspecting proxy answers 200
+    // with an HTML sign-in page, so unparseable JSON is one of the *likeliest*
+    // proxy symptoms rather than evidence the merchant was reached.
     throw new UcpError({
       layer: 'transport',
       code: ErrorCodes.TRANSPORT_INVALID_JSON,
-      message: `MCP response body is not valid JSON: ${endpoint}`,
+      message: `MCP response body is not valid JSON: ${endpoint}${proxyErrorNote()}`,
       cause: err as Error,
-      context: { endpoint, method: opts.method },
+      context: { endpoint, method: opts.method, ...proxyErrorContext() },
     })
   }
 

--- a/src/core/proxy.test.ts
+++ b/src/core/proxy.test.ts
@@ -1,0 +1,402 @@
+// core/proxy.ts — proxy env detection + undici dispatcher install.
+//
+// Two layers, deliberately:
+//
+//   1. Unit tests with an injected undici loader. This is the only way to
+//      prove the *conditional* half of the contract: no proxy env means the
+//      ~37 ms undici load never happens at all.
+//   2. Fixture-proxy tests against real undici over loopback sockets. These
+//      are what make the conditional design defensible: CONNECT tunnelling
+//      and no_proxy matching are the risky half of proxy support, and an
+//      install that silently no-ops — e.g. undici's globalThis
+//      dispatcher-symbol handshake drifting from what Node's bundled copy
+//      reads — is otherwise a regression that only reproduces on a machine
+//      behind a real proxy. Loopback only, so they run in `pnpm test`.
+
+import { createServer, type Server } from 'node:http'
+import { type AddressInfo, connect } from 'node:net'
+
+import { Agent, setGlobalDispatcher } from 'undici'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearProxyEnv } from '../test-utils.js'
+import {
+  describeProxyState,
+  installProxyDispatcher,
+  proxyErrorContext,
+  proxyErrorNote,
+  proxyState,
+  resetProxyStateForTests,
+} from './proxy.js'
+
+/**
+ * A developer or CI runner that is itself behind a proxy must not change any
+ * result here. Every test starts from a known-empty proxy environment.
+ */
+function isolateProxyEnv(): void {
+  clearProxyEnv(vi.stubEnv)
+}
+
+/** Undici double that records loads and installs without opening sockets. */
+function stubLoader() {
+  const log = { loads: 0, installs: [] as unknown[] }
+  const load = async () => {
+    log.loads += 1
+    return {
+      EnvHttpProxyAgent: class StubAgent {},
+      setGlobalDispatcher: (dispatcher: unknown) => {
+        log.installs.push(dispatcher)
+      },
+    }
+  }
+  return { load, log }
+}
+
+interface FixtureServer {
+  url: string
+  close: () => Promise<void>
+}
+
+interface FixtureProxy extends FixtureServer {
+  /**
+   * Absolute-form targets seen (`GET http://host/path`). Asserted EMPTY:
+   * undici tunnels *everything* with CONNECT, including plain http, unlike
+   * curl which forwards http in absolute form. Pinned by test because it
+   * dictates what the proxy-side ACL must allow.
+   */
+  forwarded: string[]
+  /** CONNECT targets seen, i.e. tunnelling. */
+  tunneled: string[]
+}
+
+function listening(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`)
+    })
+  })
+}
+
+function closing(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Undici keeps the tunnel socket alive after the response, so close()
+    // alone would wait forever for an idle keep-alive connection.
+    server.closeAllConnections()
+    server.close((err) => (err === undefined || err === null ? resolve() : reject(err)))
+  })
+}
+
+/**
+ * Minimal CONNECT proxy.
+ *
+ * `relay: true` completes the tunnel to the requested host, giving an
+ * end-to-end assertion that a request really traversed the proxy. `relay:
+ * false` refuses it, which is how we assert the CONNECT target for a host
+ * that does not exist without needing a TLS endpoint and a trusted cert in
+ * the test. `refuseWith` supplies the raw refusal, so a real corporate
+ * failure (407) can be reproduced byte-for-byte.
+ */
+async function startFixtureProxy(
+  opts: { relay?: boolean; refuseWith?: string } = {},
+): Promise<FixtureProxy> {
+  const forwarded: string[] = []
+  const tunneled: string[] = []
+  const server = createServer((req, res) => {
+    forwarded.push(req.url ?? '')
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('via-fixture-proxy')
+  })
+  server.on('connect', (req, clientSocket, head) => {
+    const target = req.url ?? ''
+    tunneled.push(target)
+    if (opts.relay !== true) {
+      clientSocket.end(opts.refuseWith ?? 'HTTP/1.1 502 Bad Gateway\r\n\r\n')
+      return
+    }
+    // Split on the LAST colon so an IPv6 literal host stays intact.
+    const split = target.lastIndexOf(':')
+    const upstream = connect(Number(target.slice(split + 1)), target.slice(0, split), () => {
+      clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+      if (head.length > 0) upstream.write(head)
+      upstream.pipe(clientSocket)
+      clientSocket.pipe(upstream)
+    })
+    upstream.on('error', () => clientSocket.destroy())
+    clientSocket.on('error', () => upstream.destroy())
+  })
+  const url = await listening(server)
+  return { url, forwarded, tunneled, close: () => closing(server) }
+}
+
+async function startDirectTarget(): Promise<FixtureServer & { hits: string[] }> {
+  const hits: string[] = []
+  const server = createServer((req, res) => {
+    hits.push(req.url ?? '')
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('direct')
+  })
+  const url = await listening(server)
+  return { url, hits, close: () => closing(server) }
+}
+
+beforeEach(() => {
+  isolateProxyEnv()
+})
+
+afterEach(() => {
+  // The dispatcher is process-global; restore a plain one so a proxied test
+  // cannot leak into a later one.
+  setGlobalDispatcher(new Agent())
+  vi.unstubAllEnvs()
+})
+
+describe('installProxyDispatcher — conditional load', () => {
+  it('skips the undici import entirely when no proxy env is set', async () => {
+    const { load, log } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    expect(state.status).toBe('inactive')
+    expect(state.vars).toEqual([])
+    // The whole point of the conditional design: the common path pays nothing.
+    expect(log.loads).toBe(0)
+    expect(log.installs).toHaveLength(0)
+  })
+
+  it('installs a dispatcher when https_proxy is set', async () => {
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    const { load, log } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    expect(state.status).toBe('active')
+    expect(log.loads).toBe(1)
+    expect(log.installs).toHaveLength(1)
+    expect(state.vars).toEqual(['https_proxy=http://proxy.example:3128'])
+  })
+
+  it.each([
+    'http_proxy',
+    'HTTP_PROXY',
+    'https_proxy',
+    'HTTPS_PROXY',
+  ])('triggers on %s (case handling is undici\u2019s job, presence detection is ours)', async (name) => {
+    vi.stubEnv(name, 'http://proxy.example:3128')
+    const { load } = stubLoader()
+    expect((await installProxyDispatcher({ load })).status).toBe('active')
+  })
+
+  it('treats an empty proxy value as unset (`export https_proxy=` idiom)', async () => {
+    vi.stubEnv('https_proxy', '')
+    const { load, log } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    expect(state.status).toBe('inactive')
+    expect(log.loads).toBe(0)
+    // Still reported, so `ucp doctor` can explain why we are not proxying.
+    expect(state.vars).toEqual(['https_proxy='])
+  })
+
+  it('treats a whitespace-only proxy value as unset', async () => {
+    // Regression guard: `new EnvHttpProxyAgent()` throws `Invalid URL` on a
+    // whitespace-only value, which would turn a user typo into a total
+    // outage. Trimming keeps it a direct connection instead.
+    vi.stubEnv('https_proxy', '   ')
+    const { load, log } = stubLoader()
+    expect((await installProxyDispatcher({ load })).status).toBe('inactive')
+    expect(log.loads).toBe(0)
+  })
+
+  it('does not install for no_proxy alone, but reports it', async () => {
+    vi.stubEnv('no_proxy', '.internal.example')
+    const { load, log } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    expect(state.status).toBe('inactive')
+    expect(log.loads).toBe(0)
+    expect(state.vars).toEqual(['no_proxy=.internal.example'])
+  })
+
+  it('records an error instead of throwing when undici cannot be loaded', async () => {
+    // A broken install (vendored dist without deps) must not stop
+    // `ucp --version` from working.
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    const state = await installProxyDispatcher({
+      load: () => Promise.reject(new Error('ERR_MODULE_NOT_FOUND')),
+    })
+    expect(state.status).toBe('error')
+    expect(state.error).toContain('ERR_MODULE_NOT_FOUND')
+  })
+
+  it('records an error instead of throwing when the proxy URL is malformed', async () => {
+    // Real undici here: the throw we are catching is genuinely its own.
+    vi.stubEnv('https_proxy', 'not-a-url')
+    const state = await installProxyDispatcher()
+    expect(state.status).toBe('error')
+    expect(state.error).toContain('Invalid URL')
+  })
+})
+
+describe('proxy state reporting', () => {
+  it('redacts proxy credentials', async () => {
+    vi.stubEnv('https_proxy', 'http://alice:s3cret@proxy.example:3128')
+    const { load } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    const rendered = `${state.vars.join(',')} ${describeProxyState()}`
+    expect(rendered).not.toContain('s3cret')
+    expect(rendered).toContain('***')
+    // Username survives; it is useful for debugging and is not the secret.
+    expect(rendered).toContain('alice')
+  })
+
+  // Every entry below is a shape that leaked a password past an earlier
+  // version of the redactor. They are regression pins, not hypotheticals: the
+  // value is rendered into `ucp doctor` output and error messages, which for
+  // an agent-driven CLI means a log aggregator or a model provider.
+  it.each([
+    ['ht!tp://alice:s3cret@proxy.example', 'malformed scheme, so URL parsing fails'],
+    [
+      'alice:s3cret@proxy.example:3128',
+      'scheme-less — curl accepts it, and `new URL` reads `alice:` as the scheme',
+    ],
+    [
+      '  http://alice:s3cret@proxy.example:3128',
+      'leading whitespace from `export https_proxy=" http://..."`',
+    ],
+    ['http://a:s3cret@b:s3cret@c', 'doubled userinfo — stopping at the first @ exposes the second'],
+    ['http://alice%3As3cret@proxy.example', 'percent-encoded separator'],
+    ['http://alice:s3cret\nX-Injected: 1@proxy.example', 'newline in the password'],
+    ['http://:s3cret@proxy.example', 'empty username'],
+    ['http://alice:s3cret@[::1]:3128', 'IPv6 literal host'],
+  ])('never echoes a password: %s', async (value) => {
+    vi.stubEnv('https_proxy', value)
+    const { load } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    const rendered = `${state.vars.join(',')} ${describeProxyState()} ${proxyErrorNote()}`
+    expect(rendered).not.toContain('s3cret')
+    expect(rendered).toContain('***')
+  })
+
+  it('leaves a credential-free value byte-for-byte intact', async () => {
+    // Redaction must not quietly rewrite what the user typed, or `ucp doctor`
+    // output stops matching `echo $https_proxy` and looks like a second bug.
+    vi.stubEnv('https_proxy', 'http://proxy.corp.example:3128')
+    const { load } = stubLoader()
+    const state = await installProxyDispatcher({ load })
+    expect(state.vars).toEqual(['https_proxy=http://proxy.corp.example:3128'])
+  })
+
+  it('reports "not initialized" rather than inventing an environment claim', () => {
+    // Only reachable if the bin.ts install call is dropped. The point is that
+    // it says so: reporting "no proxy env" here would state a falsehood about
+    // a proxied machine because of a wiring bug in our own boot path.
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    resetProxyStateForTests()
+    expect(describeProxyState()).toBe('state unknown (proxy setup did not run)')
+    // State still reports the environment truthfully, redacted as always.
+    expect(proxyState()).toEqual({
+      status: 'inactive',
+      vars: ['https_proxy=http://proxy.example:3128'],
+    })
+  })
+
+  it('omits error context entirely when no proxy is configured', async () => {
+    await installProxyDispatcher()
+    expect(proxyErrorContext()).toBeUndefined()
+    expect(describeProxyState()).toBe('none configured; connecting directly')
+  })
+
+  it('carries state into error context when active', async () => {
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    const { load } = stubLoader()
+    await installProxyDispatcher({ load })
+    expect(proxyErrorContext()).toEqual({ proxy: proxyState() })
+    // The summary names the variable the CLI picked up — the actionable
+    // fact — not the library doing the routing.
+    expect(describeProxyState()).toBe('enabled (https_proxy=http://proxy.example:3128)')
+  })
+
+  it('describes a failed install as the cause of direct requests', async () => {
+    vi.stubEnv('https_proxy', 'not-a-url')
+    await installProxyDispatcher()
+    expect(proxyErrorContext()).toEqual({ proxy: proxyState() })
+    expect(describeProxyState()).toContain('set but unusable')
+    expect(describeProxyState()).toContain('connecting directly')
+  })
+})
+
+describe('routing through a fixture proxy (real undici)', () => {
+  it('routes a request through the proxy end to end', async () => {
+    const proxy = await startFixtureProxy({ relay: true })
+    const origin = await startDirectTarget()
+    try {
+      vi.stubEnv('http_proxy', proxy.url)
+      expect((await installProxyDispatcher()).status).toBe('active')
+
+      const res = await fetch(`${origin.url}/profile.json`)
+      // Body proves the tunnel carried real traffic; the recorded CONNECT
+      // proves it went through the proxy rather than straight to the origin.
+      expect(await res.text()).toBe('direct')
+      expect(origin.hits).toEqual(['/profile.json'])
+      expect(proxy.tunneled).toEqual([origin.url.replace('http://', '')])
+      // Pins undici's tunnel-always behaviour: no absolute-form forwarding,
+      // even for plain http. The proxy must permit CONNECT.
+      expect(proxy.forwarded).toEqual([])
+    } finally {
+      await Promise.all([proxy.close(), origin.close()])
+    }
+  })
+
+  it('tunnels https requests with CONNECT host:443', async () => {
+    const proxy = await startFixtureProxy()
+    try {
+      vi.stubEnv('https_proxy', proxy.url)
+      expect((await installProxyDispatcher()).status).toBe('active')
+
+      // The fixture refuses the tunnel, so the request must fail — the
+      // assertion that matters is the CONNECT line it saw first.
+      await expect(fetch('https://merchant.invalid/profile.json')).rejects.toThrow()
+      expect(proxy.tunneled).toEqual(['merchant.invalid:443'])
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('surfaces a proxy 407 as a proxy failure, not a merchant failure', async () => {
+    // The most common corporate failure: authentication required. Nothing
+    // about the merchant is wrong, and the error must not imply otherwise.
+    const proxy = await startFixtureProxy({
+      refuseWith:
+        'HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="corp"\r\n\r\n',
+    })
+    try {
+      vi.stubEnv('https_proxy', proxy.url)
+      expect((await installProxyDispatcher()).status).toBe('active')
+
+      const err = await fetch('https://merchant.invalid/profile.json').catch((e: Error) => e)
+      expect(err).toBeInstanceOf(Error)
+      expect(proxy.tunneled).toEqual(['merchant.invalid:443'])
+
+      // The 407 is real but buried: undici nests it several `cause` levels
+      // deep, and the CLI's error framework lifts only the outermost message
+      // ("fetch failed"). Pinned to document that the annotation from
+      // proxyErrorNote() is what carries the diagnosis today.
+      const chain: string[] = []
+      for (let e: unknown = err; e instanceof Error; e = e.cause) chain.push(e.message)
+      expect(chain[0]).toBe('fetch failed')
+      expect(chain.join(' | ')).toContain('407')
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('bypasses the proxy for no_proxy hosts', async () => {
+    const proxy = await startFixtureProxy()
+    const direct = await startDirectTarget()
+    try {
+      vi.stubEnv('http_proxy', proxy.url)
+      vi.stubEnv('no_proxy', '127.0.0.1')
+      expect((await installProxyDispatcher()).status).toBe('active')
+
+      const res = await fetch(`${direct.url}/bypass`)
+      expect(await res.text()).toBe('direct')
+      expect(direct.hits).toEqual(['/bypass'])
+      expect(proxy.forwarded).toEqual([])
+    } finally {
+      await Promise.all([proxy.close(), direct.close()])
+    }
+  })
+})

--- a/src/core/proxy.test.ts
+++ b/src/core/proxy.test.ts
@@ -219,6 +219,29 @@ describe('installProxyDispatcher — conditional load', () => {
     })
     expect(state.status).toBe('error')
     expect(state.error).toContain('ERR_MODULE_NOT_FOUND')
+    // On a supported Node the version hint must NOT appear — it would point
+    // users at an upgrade that cannot help them.
+    expect(state.error).not.toContain('requires Node')
+  })
+
+  it('names the Node version when a load failure happens below the engines floor', async () => {
+    // Field report from a Node 18 box: undici 7's import throws "File is not
+    // defined", which does not name the actual problem — the runtime is below
+    // our engines floor. The annotation is version-based, not global-sniffing,
+    // so it covers whatever undici happens to trip over on old Node.
+    vi.stubEnv('https_proxy', 'http://proxy.example:3128')
+    const descriptor = Object.getOwnPropertyDescriptor(process.versions, 'node')
+    Object.defineProperty(process.versions, 'node', { ...descriptor, value: '18.19.1' })
+    try {
+      const state = await installProxyDispatcher({
+        load: () => Promise.reject(new ReferenceError('File is not defined')),
+      })
+      expect(state.status).toBe('error')
+      expect(state.error).toContain('File is not defined')
+      expect(state.error).toContain('(Node v18.19.1; ucp requires Node >= 22)')
+    } finally {
+      Object.defineProperty(process.versions, 'node', descriptor as PropertyDescriptor)
+    }
   })
 
   it('records an error instead of throwing when the proxy URL is malformed', async () => {

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -1,0 +1,229 @@
+// Proxy support for outbound HTTP on corporate/sandboxed networks.
+//
+// Node's built-in `fetch` ignores `https_proxy` / `http_proxy` / `no_proxy`
+// unless the process was started with `--use-env-proxy` (Node >= 22.21 /
+// >= 24.5); the switch cannot be enabled from inside the process, and global
+// http(s) agents do not affect `fetch()`. Installing an undici dispatcher
+// that reads the same env contract is the one in-process fix. Without it, a
+// proxied box stalls for the request timeout and reports a bare `fetch
+// failed` — indistinguishable from a dead merchant.
+//
+// The dispatcher is installed only when a proxy var is set:
+//   - a routine undici bump must not silently change the transport under
+//     checkout for the majority who have no proxy;
+//   - the undici import is ~1/3 of CLI cold start, and agents invoke the
+//     CLI several times per session.
+//
+// Env-var precedence and the no_proxy grammar are undici's, not ours; this
+// module answers only "is a proxy configured?" and reports what it saw. The
+// resulting divergences from curl (no ALL_PROXY, no CIDR in no_proxy,
+// scheme-less values rejected, socks5 untested) are documented in README
+// "Proxies and TLS inspection".
+//
+// State is module-scoped like verbose.ts: a process-lifetime property
+// decided once at boot. `bin.ts` installs; doctor and transport error paths
+// read.
+
+/**
+ * Vars whose presence installs the dispatcher. Case variants are listed
+ * because presence detection is ours; precedence between them is undici's.
+ */
+const TRIGGER_VARS = ['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY'] as const
+
+/**
+ * Reported for context but never a trigger on their own — `no_proxy` with no
+ * proxy configured has nothing to exclude.
+ */
+const CONTEXT_VARS = ['no_proxy', 'NO_PROXY'] as const
+
+export type ProxyStatus = 'inactive' | 'active' | 'error'
+
+export interface ProxyState {
+  /**
+   * `inactive` — no usable proxy env; direct connections (the common path).
+   * `active` — dispatcher installed; requests are subject to the proxy env.
+   * `error` — proxy env present but unusable, so requests went direct. Must
+   * never be silent: it looks exactly like a broken merchant.
+   */
+  status: ProxyStatus
+  /** Redacted `name=value` for every proxy-related var present in the env. */
+  vars: string[]
+  /** Failure reason. Present only when `status === 'error'`. */
+  error?: string
+}
+
+/**
+ * The undici surface we use, typed structurally so tests can inject a plain
+ * object double without constructing a real agent.
+ */
+interface UndiciProxySupport {
+  EnvHttpProxyAgent: new () => unknown
+  setGlobalDispatcher: (dispatcher: unknown) => void
+}
+
+export interface ProxyInstallOptions {
+  /**
+   * Injectable undici loader; defaults to a dynamic import so the no-proxy
+   * path never loads undici. Tests use it to assert exactly that, and to
+   * simulate undici missing from a broken install.
+   */
+  load?: () => Promise<UndiciProxySupport>
+}
+
+// null until the installer runs. "Not initialized" must stay distinguishable
+// from "initialized, found nothing": rendering the latter for the former
+// would claim a clean environment on a proxied box.
+let state: ProxyState | null = null
+
+const loadUndici = (): Promise<UndiciProxySupport> =>
+  import('undici') as unknown as Promise<UndiciProxySupport>
+
+/**
+ * Proxy state decided at boot. Before the installer runs, reports the env
+ * as it actually is with nothing installed.
+ */
+export function proxyState(): ProxyState {
+  return state ?? { status: 'inactive', vars: describeProxyVars() }
+}
+
+/**
+ * Detect proxy env and, when present, install undici's `EnvHttpProxyAgent`
+ * as the process-global fetch dispatcher.
+ *
+ * Must be called from `bin.ts` only: `index.ts` declares `"sideEffects":
+ * false`, so importing the library must never mutate the global dispatcher.
+ *
+ * Never throws — a malformed `https_proxy` must not stop `ucp --version`.
+ * Failures land in `status: 'error'` and surface through `ucp doctor` and
+ * transport-error messages.
+ */
+export async function installProxyDispatcher(opts: ProxyInstallOptions = {}): Promise<ProxyState> {
+  const vars = describeProxyVars()
+  if (!hasProxyConfigured()) {
+    state = { status: 'inactive', vars }
+    return state
+  }
+  try {
+    const undici = await (opts.load ?? loadUndici)()
+    // No-arg construction: the agent reads process.env itself, keeping a
+    // single implementation of the env contract in play.
+    undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent())
+    state = { status: 'active', vars }
+  } catch (err) {
+    // Redact the failure text too: it reaches doctor output and error
+    // envelopes, and undici embedding the proxy URI someday must not leak.
+    state = { status: 'error', vars, error: redactProxyValue((err as Error).message) }
+  }
+  return state
+}
+
+/**
+ * Proxy annotation for transport-error `context`; `undefined` when no proxy
+ * is configured, so the common path adds nothing to error envelopes.
+ *
+ * `context` does not reach the CLI envelope today — incur emits only
+ * `{code, message, retryable}` (see core/operation.ts). Set for parity with
+ * other transport errors and for when passthrough lands;
+ * {@link proxyErrorNote} is what a user or agent actually sees.
+ */
+export function proxyErrorContext(): { proxy: ProxyState } | undefined {
+  const current = proxyState()
+  return current.status === 'inactive' ? undefined : { proxy: current }
+}
+
+/**
+ * Message suffix for transport failures; empty when no proxy is configured.
+ * Lives in the message because incur drops `context` (see
+ * {@link proxyErrorContext}) — and without it a proxy failure and an
+ * unreachable merchant render identically.
+ */
+export function proxyErrorNote(): string {
+  return proxyState().status === 'inactive' ? '' : ` [proxy: ${describeProxyState()}]`
+}
+
+/**
+ * One-line human summary. Rendered by the verbose trace, `ucp doctor`, and
+ * transport-error messages. Names the variables, not the implementation:
+ * "which env var did the CLI pick up, and is my traffic subject to it" is
+ * the actionable information; the library doing the routing is not.
+ */
+export function describeProxyState(): string {
+  // Reachable only if the bin.ts install call is bypassed. Say so rather
+  // than render an environment claim nothing verified.
+  if (state === null) return 'state unknown (proxy setup did not run)'
+  const { status, vars, error } = state
+  const seen = vars.length === 0 ? '' : ` (${vars.join(', ')})`
+  switch (status) {
+    case 'active':
+      // "enabled", not "routing": nothing here has exercised the proxy. A
+      // dead or 407-ing proxy still reaches this branch.
+      return `enabled${seen}`
+    case 'error':
+      return `set but unusable: ${error} — connecting directly${seen}`
+    default:
+      return vars.length === 0
+        ? 'none configured; connecting directly'
+        : `none usable; connecting directly${seen}`
+  }
+}
+
+/**
+ * True when at least one trigger var holds a non-blank value. Blank counts
+ * as unset: `export https_proxy=` is the common disable idiom, and a
+ * whitespace-only value makes `new EnvHttpProxyAgent()` throw — a typo must
+ * not become a total outage.
+ */
+function hasProxyConfigured(): boolean {
+  return TRIGGER_VARS.some((name) => (process.env[name] ?? '').trim() !== '')
+}
+
+/** Reset for tests. Restores the pre-install state; installs nothing. */
+export function resetProxyStateForTests(): void {
+  state = null
+}
+
+/** Redacted `name=value` for each proxy-related var present in the env. */
+function describeProxyVars(): string[] {
+  const described: string[] = []
+  for (const name of [...TRIGGER_VARS, ...CONTEXT_VARS]) {
+    const value = process.env[name]
+    if (value === undefined) continue
+    described.push(`${name}=${redactProxyValue(value)}`)
+  }
+  return described
+}
+
+/**
+ * Strip the password from a proxy value before it reaches doctor output, the
+ * verbose trace, or an error message: `http://user:pw@proxy:8080` →
+ * `http://user:***@proxy:8080`. The username is kept — useful for debugging
+ * and not the secret.
+ *
+ * Never parse this with `new URL()`. The parser *succeeds* on the
+ * scheme-less `user:pw@host:port` form curl accepts — reading `user:` as the
+ * scheme and leaving `url.password` empty while the password sits in plain
+ * sight — and a parse failure on a malformed value (the values most in need
+ * of printing) must never cause a verbatim echo. Hence the index scan over
+ * the raw string; the shapes that leaked past earlier versions are pinned in
+ * proxy.test.ts.
+ */
+function redactProxyValue(value: string): string {
+  // Trim first: leading whitespace must not slide a password past the scan.
+  const trimmed = value.trim()
+  const schemeEnd = trimmed.indexOf('://')
+  const authorityStart = schemeEnd === -1 ? 0 : schemeEnd + 3
+  const pathStart = trimmed.indexOf('/', authorityStart)
+  const authorityEnd = pathStart === -1 ? trimmed.length : pathStart
+  // LAST '@' in the authority: a doubled userinfo is malformed but still
+  // printed, and stopping at the first '@' would expose what follows.
+  const at = trimmed.lastIndexOf('@', authorityEnd)
+  if (at === -1) return trimmed
+  const userinfo = trimmed.slice(authorityStart, at)
+  // `%3A` is username content per WHATWG URL, not a separator — but whoever
+  // wrote it meant a separator, and over-redacting a username is cheaper
+  // than printing a password.
+  const separator = userinfo.search(/:|%3a/i)
+  // No separator means username-only; the username is not the secret.
+  if (separator === -1) return trimmed
+  return `${trimmed.slice(0, authorityStart)}${userinfo.slice(0, separator)}:***@${trimmed.slice(at + 1)}`
+}

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -25,16 +25,18 @@
 // read.
 
 /**
- * Vars whose presence installs the dispatcher. Case variants are listed
- * because presence detection is ours; precedence between them is undici's.
+ * Logical variable names, matched case-insensitively against the actual env
+ * keys — never probed as fixed-name properties. Windows env vars are
+ * case-insensitive on property access, so checking `https_proxy` and
+ * `HTTPS_PROXY` separately reports one OS variable twice; enumerating real
+ * keys reports each variable exactly once with the casing the user set, on
+ * every platform. Precedence between variants is undici's job.
+ *
+ * `no_proxy` is reported for context but never a trigger on its own — with
+ * no proxy configured it has nothing to exclude.
  */
-const TRIGGER_VARS = ['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY'] as const
-
-/**
- * Reported for context but never a trigger on their own — `no_proxy` with no
- * proxy configured has nothing to exclude.
- */
-const CONTEXT_VARS = ['no_proxy', 'NO_PROXY'] as const
+const TRIGGER_NAMES = ['https_proxy', 'http_proxy'] as const
+const PROXY_NAMES = [...TRIGGER_NAMES, 'no_proxy'] as const
 
 export type ProxyStatus = 'inactive' | 'active' | 'error'
 
@@ -174,7 +176,27 @@ export function describeProxyState(): string {
  * not become a total outage.
  */
 function hasProxyConfigured(): boolean {
-  return TRIGGER_VARS.some((name) => (process.env[name] ?? '').trim() !== '')
+  return proxyEnvEntries().some(
+    ([key, value]) =>
+      (TRIGGER_NAMES as readonly string[]).includes(key.toLowerCase()) && value.trim() !== '',
+  )
+}
+
+/**
+ * Actual proxy-related env entries, each underlying variable exactly once
+ * (see {@link PROXY_NAMES}). Sorted by logical name then lowercase-first so
+ * rendered output is deterministic regardless of env-block order.
+ */
+function proxyEnvEntries(): Array<[string, string]> {
+  const rank = (key: string): number => PROXY_NAMES.indexOf(key.toLowerCase() as never)
+  // Within one logical name, exact-lowercase sorts first — that is the
+  // variant undici actually prefers, so display order mirrors precedence.
+  const caseRank = (key: string): number => (key === key.toLowerCase() ? 0 : 1)
+  return Object.entries(process.env)
+    .filter(
+      (entry): entry is [string, string] => rank(entry[0]) !== -1 && typeof entry[1] === 'string',
+    )
+    .sort(([a], [b]) => rank(a) - rank(b) || caseRank(a) - caseRank(b))
 }
 
 /** Reset for tests. Restores the pre-install state; installs nothing. */
@@ -184,13 +206,7 @@ export function resetProxyStateForTests(): void {
 
 /** Redacted `name=value` for each proxy-related var present in the env. */
 function describeProxyVars(): string[] {
-  const described: string[] = []
-  for (const name of [...TRIGGER_VARS, ...CONTEXT_VARS]) {
-    const value = process.env[name]
-    if (value === undefined) continue
-    described.push(`${name}=${redactProxyValue(value)}`)
-  }
-  return described
+  return proxyEnvEntries().map(([key, value]) => `${key}=${redactProxyValue(value)}`)
 }
 
 /**

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -114,7 +114,18 @@ export async function installProxyDispatcher(opts: ProxyInstallOptions = {}): Pr
   } catch (err) {
     // Redact the failure text too: it reaches doctor output and error
     // envelopes, and undici embedding the proxy URI someday must not leak.
-    state = { status: 'error', vars, error: redactProxyValue((err as Error).message) }
+    //
+    // Below the engines floor the failure is the import itself — undici 7
+    // references globals older Node lacks — and the raw error ("File is not
+    // defined") does not name the actual problem. Annotate with the version
+    // rather than pre-checking specific globals, which would couple us to
+    // undici's internals.
+    const nodeVersion = process.versions.node
+    const versionHint =
+      Number(nodeVersion.split('.', 1)[0]) < __MIN_NODE_MAJOR__
+        ? ` (Node v${nodeVersion}; ucp requires Node >= ${__MIN_NODE_MAJOR__})`
+        : ''
+    state = { status: 'error', vars, error: redactProxyValue((err as Error).message) + versionHint }
   }
   return state
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -4,3 +4,4 @@ declare const __DEFAULT_PROFILE_URL__: string
 declare const __DEFAULT_CATALOG_URL__: string
 declare const __PROTOCOL_MIN__: string
 declare const __PROTOCOL_MAX__: string
+declare const __MIN_NODE_MAJOR__: number

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -91,3 +91,28 @@ export function captureSaves(
     },
   }
 }
+
+// Proxy-env isolation for tests.
+//
+// All six vars must be cleared, not just the four triggers: NO_PROXY/no_proxy
+// change the rendered proxy summary by their mere presence, so a test that
+// clears less passes on a clean laptop and fails on a proxied CI runner — the
+// exact environment the proxy feature serves.
+//
+// Cleanup must call `resetProxyStateForTests()`, never the installer: running
+// `installProxyDispatcher()` after `vi.unstubAllEnvs()` would install the
+// developer's real corporate proxy as the process-global dispatcher for the
+// rest of the worker.
+export const PROXY_ENV_VARS = [
+  'http_proxy',
+  'HTTP_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'no_proxy',
+  'NO_PROXY',
+] as const
+
+/** Clear every proxy var so assertions do not depend on the host env. */
+export function clearProxyEnv(stubEnv: (name: string, value: undefined) => void): void {
+  for (const name of PROXY_ENV_VARS) stubEnv(name, undefined)
+}


### PR DESCRIPTION
   Node's built-in fetch ignores https_proxy/no_proxy unless the process
   was started with --use-env-proxy, and that switch cannot be enabled
   from inside the process. On a box where curl works, ucp stalled for
   the full 30s request timeout and reported a bare "fetch failed" —
   indistinguishable from a dead merchant, and an agent relays it as
   exactly that. Misattribution, not latency, is the bug being fixed.

   Architecture: one seam, src/core/proxy.ts, decided once at boot. When
   a proxy variable holds a usable value, bin.ts lazily imports undici
   and installs EnvHttpProxyAgent as the process-global fetch dispatcher;
   otherwise undici is never loaded. Conditional by design: a routine
   undici bump must not silently change the transport under checkout for
   the no-proxy majority, and the import is ~1/3 of CLI cold start.
   Installed from the bin entrypoint only — index.ts declares
   "sideEffects": false, so library consumers never inherit a global
   dispatcher mutation. Env-var precedence and the no_proxy grammar are
   delegated to undici wholesale; this module answers one question, "is
   a proxy configured?", and reports what it saw. The resulting
   divergences from curl (no ALL_PROXY, no CIDR in no_proxy, scheme
   required, socks5 untested) are documented in the README.

   Posture: a proxy in the path must be impossible to miss, and a broken
   one must never be silent. `ucp doctor` gains a proxy check that fails
   when a variable is set but unusable; --verbose leads with the proxy
   decision; transport, HTTP-status, and invalid-body errors carry a
   [proxy: ...] note, because a filtering proxy answers on the
   merchant's behalf — its own 403, or a sign-in page served as 200 —
   so bytes coming back is not proof the merchant was reached. Messages
   name the variables picked up, never the implementation. The installer
   never throws: a malformed https_proxy cannot break `ucp --version`.

   Security: proxy passwords are stripped from every output path by an
   index scan over the raw value. new URL() is deliberately not used —
   it parses the scheme-less user:pw@host form curl accepts with an
   empty .password while the secret sits in plain sight. Every shape
   that leaked past earlier revisions (scheme-less, leading whitespace,
   doubled userinfo, %3A separator) is pinned as a regression test. No
   new trust surface: TLS verification is untouched, and CA trust for
   TLS-inspecting proxies stays on Node's own NODE_EXTRA_CA_CERTS /
   NODE_USE_SYSTEM_CA.

   Validated against a hermetic loopback CONNECT proxy: end-to-end
   tunneling, no_proxy bypass, 407 auth refusal, captive-portal and
   block-page annotation, plus full-env isolation so the suite passes
   on proxied CI runners.