### PR TITLE
fix: pin MCP tool discovery to 'direct'; align incur with fresh installs

### DIFF
--- a/.changeset/pin-mcp-direct-discovery.md
+++ b/.changeset/pin-mcp-direct-discovery.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ucp-cli': patch
+---
+
+Restore the per-command MCP tool surface (`catalog_search`, `cart_create`, ...). a later incur 0.4.x release flipped its MCP tool discovery default to 'progressive', which replaced this CLI's published tools with four search/inspect/execute meta-tools on any fresh install resolving a newer incur. Tool discovery is now pinned to 'direct' and covered by an integration test, and the locked incur is aligned with what fresh installs resolve (0.4.26).

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@jmespath-community/jmespath": "^1.3.0",
-    "incur": "^0.4.10",
+    "incur": "^0.4.26",
     "undici": "^7.29.0",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       incur:
-        specifier: ^0.4.10
-        version: 0.4.10
+        specifier: ^0.4.26
+        version: 0.4.26
       undici:
         specifier: ^7.29.0
         version: 7.29.0
@@ -963,8 +963,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==, tarball: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz}
     engines: {node: '>= 4'}
 
-  incur@0.4.10:
-    resolution: {integrity: sha512-u35+Ba0oJOPQnAYxYPo5j91P/rI9kTtpDf/iJe6kOs335iguz8mYnVguex4NP6GmIP6uc7iqUWY5cmdc/0MwTw==, tarball: https://registry.npmjs.org/incur/-/incur-0.4.10.tgz}
+  incur@0.4.26:
+    resolution: {integrity: sha512-63lwOc8+o1VeFkIW3sWWMrDSP5Dd1NsvucUWyxLUk+DoNRiNl7cj481nlLdlboXkq+tqYPBSlV/7XbylS2S4BA==, tarball: https://registry.npmjs.org/incur/-/incur-0.4.26.tgz}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -2349,7 +2349,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  incur@0.4.10:
+  incur@0.4.26:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,14 @@ export function createUcpCli(deps: UcpCliDependencies = {}) {
     description: CLI_DESCRIPTION,
     format: 'json',
     version: __CLI_VERSION__,
+    mcp: {
+      // incur 0.5 defaults MCP tool discovery to 'progressive' (search /
+      // inspect / execute meta-tools). Pin 'direct': one tool per command
+      // (catalog_search, cart_create, ...) is this CLI's published agent
+      // contract, and a dependency default must not rewrite it. Moving to
+      // progressive discovery is a product decision with its own migration.
+      tools: { discovery: 'direct' },
+    },
     sync: {
       // 'skills/*' surfaces every hand-written skills/<dir>/SKILL.md. The bin
       // entrypoint intercepts `skills add` and post-prunes everything else

--- a/test/integration/smoke.integration.test.ts
+++ b/test/integration/smoke.integration.test.ts
@@ -262,6 +262,34 @@ describe('smoke: --mcp stdio', () => {
     return env
   }
 
+  // Regression pin for the incur 0.4.x 'progressive' discovery default flip,
+  // which silently replaced the per-command tool surface with four
+  // search/inspect/execute meta-tools. The per-command names below are the
+  // published agent contract; cli.ts pins discovery: 'direct' to keep it.
+  // If this fails with ~4 tools, an incur bump flipped the default again.
+  it('exposes one tool per command under tools/list (direct discovery)', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'ucp-mcp-tools-'))
+    await mkdir(home, { recursive: true })
+    const env = envFor(home)
+    await execFileAsync('node', [CLI_PATH, 'profile', 'init', '--name', 'agent'], { env })
+
+    const mcp = launch(env)
+    try {
+      await initialize(mcp)
+      mcp.send({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      const response = (await mcp.waitForResponseId(1)) as {
+        result: { tools: { name: string }[] }
+      }
+      const names = response.result.tools.map((t) => t.name)
+      for (const expected of ['catalog_search', 'cart_create', 'checkout_complete', 'discover']) {
+        expect(names).toContain(expected)
+      }
+      expect(names.length).toBeGreaterThanOrEqual(20)
+    } finally {
+      await mcp.close()
+    }
+  })
+
   // The single user-facing promise of `--mcp`: an agent that has already run
   // `ucp use <url>` doesn't have to re-supply `business` on every tool call.
   // If session resolution silently broke under MCP, agents would


### PR DESCRIPTION
fix: pin MCP tool discovery to 'direct'; align incur with fresh installs

A later incur 0.4.x release flipped its MCP tool discovery default to
'progressive', exposing four search/inspect/execute meta-tools instead
of one tool per command. Because the manifest range (^0.4.10) admits
those releases, every fresh install already resolves the flipped
default — the published agent contract (catalog_search, cart_create,
...) was silently broken for new installs while CI, pinned to 0.4.10
by the lockfile, stayed green.

Pin discovery to 'direct' at the root Cli.create so a dependency
default cannot rewrite the tool surface, update incur to 0.4.26 so CI
tests what fresh installs actually resolve, and add a tools/list
integration test that names the contract instead of failing as an
undefined property read. Adopting progressive discovery stays
available as a deliberate migration with its own docs and tests.
