### PR TITLE
fix: migrate changesets/action inputs to v2 names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: pnpm version-packages
-          publish: pnpm release
+          version-script: pnpm version-packages
+          publish-script: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Second half of the changesets/action v1->v2 migration started by the dependabot SHA bump (#36): v2 renamed the version/publish inputs to version-script/publish-script and hard-fails on the old names. The CLI-side half (Changesets v3) landed in #41; this completes the pair. The Release workflow only runs on pushes to main, so PR checks cannot exercise it — verified by reading the action's v2 input schema.