### PR TITLE
Follow supported_versions when a business profile is ahead of the CLI's range

### DIFF
--- a/.changeset/supported-versions-fallback.md
+++ b/.changeset/supported-versions-fallback.md
@@ -1,0 +1,11 @@
+---
+"@shopify/ucp-cli": minor
+---
+
+Follow `supported_versions` when a business profile is ahead of the CLI's protocol range.
+
+Discovery implements the spec's "Protocol Version" fallback: when `/.well-known/ucp` is rendered at a version outside `[protocolMin, protocolMax]`, the most recent in-range `supported_versions` document is fetched and negotiated against instead, after verifying its `ucp.version` matches the key. A future spec release that keeps publishing an in-range rendering no longer breaks the CLI until it is updated.
+
+- New `PROFILE_VERSION_MISMATCH` error code for a `supported_versions` document whose `ucp.version` disagrees with its key (the spec says such a document must not be used).
+- `PROTOCOL_VERSION_INCOMPATIBLE` now lists the versions the business offered.
+- Version-specific documents cache under `businesses/<version>/<origin>.json`.

--- a/skills/ucp/references/REFERENCE.md
+++ b/skills/ucp/references/REFERENCE.md
@@ -35,6 +35,8 @@ Branch on `code` first; CTAs (when present) carry recovery suggestions.
 | `OPERATION_NOT_OFFERED` | Merchant doesn't expose this operation | `ucp discover --business <url>` to see what's offered |
 | `INVALID_INPUT` | CLI-side parse/validation error (bad JSON, missing required positional, malformed URL) | Check the message; usually self-explanatory |
 | `PROFILE_FETCH_FAILED` | Merchant doesn't speak UCP (or `.well-known/ucp` is unreachable) | Surface to buyer; offer non-UCP fallback (other tools, navigation, alternate merchants with consent) |
+| `PROTOCOL_VERSION_INCOMPATIBLE` | Merchant's `/.well-known/ucp` version and every `supported_versions` entry fall outside this CLI's range (see `context.supportedVersions`) | Upgrade the CLI (`npm i -g @shopify/ucp-cli@latest`); if already current, the merchant is ahead of the spec release this CLI ships |
+| `PROFILE_VERSION_MISMATCH` | A `supported_versions` document declares a different `ucp.version` than the key linking to it; spec forbids using it | Merchant-side bug; surface to buyer and treat like `PROFILE_FETCH_FAILED` |
 | `PROFILE_NOT_FOUND` | No active agent profile | `ucp profile init --name <name>` (see `references/SETUP.md`) |
 | `AUTH_REQUIRED` | Merchant requires authentication (HTTP 401) | This CLI doesn't implement merchant-specific auth (JWT, OAuth, API key). Handoff using the best prior URL: checkout/cart `continue_url`, then `variant.checkout_url`, then variant/product `url`, then `seller.url`, then `--business` URL or `https://<seller.domain>`. |
 | `INSUFFICIENT_PERMISSIONS` | Authenticated but lacks required scope (HTTP 403) | Same recovery as `AUTH_REQUIRED` — handoff using the same URL priority. |

--- a/src/core/discover.test.ts
+++ b/src/core/discover.test.ts
@@ -52,6 +52,11 @@ interface MockFetchOpts {
   profileCacheControl?: string
   /** Body returned for the JSON-RPC POST (defaults to SAMPLE_TOOLS_LIST). */
   toolsList?: object
+  /**
+   * Bodies served at `/.well-known/ucp/<version>` (the `supported_versions`
+   * leaves), keyed by version. Unlisted versions 404.
+   */
+  versionedProfiles?: Record<string, object>
 }
 
 function mockFetch(opts: MockFetchOpts = {}): {
@@ -69,6 +74,15 @@ function mockFetch(opts: MockFetchOpts = {}): {
           'content-type': 'application/json',
           'cache-control': opts.profileCacheControl ?? 'max-age=300',
         },
+      })
+    }
+    const versioned = /\/\.well-known\/ucp\/([^/]+)$/.exec(u)
+    if (versioned !== null) {
+      const body = opts.versionedProfiles?.[versioned[1] as string]
+      if (body === undefined) return new Response('not found', { status: 404 })
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json', 'cache-control': 'max-age=300' },
       })
     }
     const requestBody =
@@ -311,5 +325,176 @@ describe('discover — error propagation', () => {
     const entries = await readdir(toolsDir)
     expect(entries).toHaveLength(1)
     expect(entries[0]).toMatch(/^[a-f0-9]{64}\.json$/)
+  })
+})
+
+// ─── supported_versions fallback ────────────────────────────────────────
+//
+// Spec "Protocol Version": when `/.well-known/ucp` is rendered at a version
+// outside our range, pick the most recent in-range `supported_versions` key,
+// fetch its document, and verify the document's `ucp.version` matches the key.
+
+describe('discover — supported_versions fallback', () => {
+  let cacheDir: string
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'ucp-discover-sv-'))
+  })
+
+  afterEach(async () => {
+    await rm(cacheDir, { recursive: true, force: true })
+  })
+
+  const FUTURE = '2027-01-01'
+  /** Most recent version inside RANGE; the rendering the fallback must select. */
+  const LEAF = RANGE.max
+  const LEAF_URL = `${BUSINESS_URL}/.well-known/ucp/${LEAF}`
+
+  /** Top-level profile rendered one release ahead of RANGE.max. */
+  const AHEAD_PROFILE = {
+    ucp: {
+      version: FUTURE,
+      supported_versions: {
+        [LEAF]: LEAF_URL,
+        '2026-01-23': `${BUSINESS_URL}/.well-known/ucp/2026-01-23`,
+      },
+      services: {
+        'dev.ucp.shopping': [{ version: FUTURE, transport: 'mcp', endpoint: MCP_ENDPOINT }],
+      },
+      payment_handlers: {},
+    },
+  }
+
+  it('uses the most recent in-range supported_versions rendering when the top-level version is ahead of the agent range', async () => {
+    const { fetch, calls } = mockFetch({
+      profile: AHEAD_PROFILE,
+      versionedProfiles: {
+        [LEAF]: SAMPLE_PROFILE,
+        '2026-01-23': { ...SAMPLE_PROFILE, ucp: { ...SAMPLE_PROFILE.ucp, version: '2026-01-23' } },
+      },
+    })
+    const result = await discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch })
+
+    expect(result.profile.ucp.version).toBe(LEAF)
+    expect(result.negotiated['dev.ucp.shopping']?.version).toBe(LEAF)
+    expect(result.negotiated['dev.ucp.shopping']?.endpoint).toBe(MCP_ENDPOINT)
+
+    const gets = calls.filter((c) => c.method === 'GET').map((c) => c.url)
+    expect(gets).toEqual([`${BUSINESS_URL}/.well-known/ucp`, LEAF_URL])
+  })
+
+  it('does not consult supported_versions when the top-level version is already in range', async () => {
+    const profile = {
+      ...SAMPLE_PROFILE,
+      ucp: { ...SAMPLE_PROFILE.ucp, supported_versions: { '2026-01-23': LEAF_URL } },
+    }
+    const { fetch, calls } = mockFetch({ profile })
+    await discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch })
+
+    const gets = calls.filter((c) => c.method === 'GET').map((c) => c.url)
+    expect(gets).toEqual([`${BUSINESS_URL}/.well-known/ucp`])
+  })
+
+  it('caches the versioned rendering separately from the top-level document', async () => {
+    const { fetch, calls } = mockFetch({
+      profile: AHEAD_PROFILE,
+      versionedProfiles: { [LEAF]: SAMPLE_PROFILE },
+    })
+    await discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch })
+    const firstPass = calls.length
+
+    const top = JSON.parse(
+      await readFile(join(cacheDir, 'businesses', 'shop.example.invalid.json'), 'utf8'),
+    ) as { body: { ucp: { version: string } } }
+    const leaf = JSON.parse(
+      await readFile(join(cacheDir, 'businesses', LEAF, 'shop.example.invalid.json'), 'utf8'),
+    ) as { body: { ucp: { version: string } } }
+    expect(top.body.ucp.version).toBe(FUTURE)
+    expect(leaf.body.ucp.version).toBe(LEAF)
+
+    await discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch })
+    expect(calls.length).toBe(firstPass)
+  })
+
+  it('throws PROTOCOL_VERSION_INCOMPATIBLE listing supported_versions when nothing is in range', async () => {
+    const profile = {
+      ...AHEAD_PROFILE,
+      ucp: { ...AHEAD_PROFILE.ucp, supported_versions: { '2026-12-01': LEAF_URL } },
+    }
+    const { fetch } = mockFetch({ profile })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({
+      code: 'PROTOCOL_VERSION_INCOMPATIBLE',
+      layer: 'transport',
+      context: { version: FUTURE, supportedVersions: ['2026-12-01'] },
+    })
+  })
+
+  it('throws PROTOCOL_VERSION_INCOMPATIBLE when the top-level version is ahead and supported_versions is absent', async () => {
+    const { supported_versions: _omit, ...ucp } = AHEAD_PROFILE.ucp
+    const { fetch } = mockFetch({ profile: { ucp } })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({
+      code: 'PROTOCOL_VERSION_INCOMPATIBLE',
+      context: { supportedVersions: [] },
+    })
+  })
+
+  it('refuses a versioned rendering whose ucp.version does not match its supported_versions key', async () => {
+    const { fetch } = mockFetch({
+      profile: AHEAD_PROFILE,
+      versionedProfiles: {
+        [LEAF]: { ...SAMPLE_PROFILE, ucp: { ...SAMPLE_PROFILE.ucp, version: RANGE.min } },
+      },
+    })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({
+      code: 'PROFILE_VERSION_MISMATCH',
+      layer: 'transport',
+      context: { expected: LEAF, actual: RANGE.min, url: LEAF_URL },
+    })
+  })
+
+  it('reads supported_versions even when the top-level document no longer fits the full profile schema', async () => {
+    // A future release could reshape the profile envelope. The fallback must
+    // still be reachable, otherwise it cannot do the one job it exists for.
+    const profile = { ...AHEAD_PROFILE, ucp: { ...AHEAD_PROFILE.ucp, services: 'reshaped' } }
+    const { fetch } = mockFetch({ profile, versionedProfiles: { [LEAF]: SAMPLE_PROFILE } })
+    const result = await discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch })
+    expect(result.negotiated['dev.ucp.shopping']?.version).toBe(LEAF)
+  })
+
+  it('still validates an in-range top-level document against the full profile schema', async () => {
+    const profile = { ...SAMPLE_PROFILE, ucp: { ...SAMPLE_PROFILE.ucp, services: 'reshaped' } }
+    const { fetch } = mockFetch({ profile })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({ code: 'PROFILE_SCHEMA_INVALID', layer: 'transport' })
+  })
+
+  it('surfaces a failed versioned fetch as PROFILE_FETCH_FAILED', async () => {
+    const { fetch } = mockFetch({ profile: AHEAD_PROFILE, versionedProfiles: {} })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({ code: 'PROFILE_FETCH_FAILED' })
+  })
+
+  it('rejects a non-https supported_versions URL as PROFILE_SCHEMA_INVALID', async () => {
+    const profile = {
+      ...AHEAD_PROFILE,
+      ucp: {
+        ...AHEAD_PROFILE.ucp,
+        supported_versions: {
+          [LEAF]: `http://shop.example.invalid/.well-known/ucp/${LEAF}`,
+        },
+      },
+    }
+    const { fetch } = mockFetch({ profile })
+    await expect(
+      discover(BUSINESS_URL, { cacheDir, agentRange: RANGE, fetch }),
+    ).rejects.toMatchObject({ code: 'PROFILE_SCHEMA_INVALID', layer: 'transport' })
   })
 })

--- a/src/core/discover.ts
+++ b/src/core/discover.ts
@@ -12,6 +12,7 @@
 //
 // Cache layout:
 //   <ucpHome>/cache/businesses/<origin>.json
+//   <ucpHome>/cache/businesses/<version>/<origin>.json   (supported_versions)
 //   <ucpHome>/cache/toolslist/<origin>/<capability-or-hash>.json
 
 import { createHash } from 'node:crypto'
@@ -28,7 +29,8 @@ import {
   AGENT_PROTOCOL_RANGE,
   type AgentRange,
   type BusinessProfile,
-  fetchBusinessProfile,
+  fetchCompatibleBusinessProfile,
+  isVersionInRange,
 } from './profile.js'
 import { parseHttpsUrl } from './url.js'
 import { vlog } from './verbose.js'
@@ -120,8 +122,10 @@ export async function discover(
   const profileCacheDir = join(cacheRoot, 'businesses')
   const toolsListCacheRoot = join(cacheRoot, 'toolslist', originToFilename(normalizedBusiness))
 
-  const profile = await fetchBusinessProfile(normalizedBusiness.origin, {
+  const agentRange = options.agentRange ?? AGENT_PROTOCOL_RANGE
+  const resolved = await fetchCompatibleBusinessProfile(normalizedBusiness.origin, {
     cacheDir: profileCacheDir,
+    agentRange,
     ...omitUndefined({
       fetch: options.fetch,
       signal: options.signal,
@@ -129,6 +133,12 @@ export async function discover(
       headers: options.headers,
     }),
   })
+  const { profile } = resolved
+  if (resolved.fromSupportedVersions) {
+    vlog(
+      `discover: /.well-known/ucp is outside agent range [${agentRange.min}..${agentRange.max}]; using supported_versions[${resolved.version}] → ${resolved.profileUrl}`,
+    )
+  }
 
   const services = profile.ucp.services as Record<string, unknown> | undefined
   const requested =
@@ -139,7 +149,7 @@ export async function discover(
     const negotiation = negotiateService({
       profile,
       capability,
-      agentRange: options.agentRange ?? AGENT_PROTOCOL_RANGE,
+      agentRange,
       ...omitUndefined({ acceptableTransports: options.acceptableTransports }),
     })
     const endpoint = negotiation.entry.endpoint
@@ -252,10 +262,11 @@ function profileParams(profileUrl: string): {
 //
 // What this is NOT:
 //
-//   • Profile-level `supported_versions` handling. That's pre-flight: if
-//     the business profile is rendered at a version we can't parse,
-//     `supported_versions[<our pick>]` lets us re-fetch a different
-//     rendering. That's handled before we get here.
+//   • Profile-level `supported_versions` handling. That's pre-flight: when
+//     the top-level profile's `ucp.version` is outside our range,
+//     `fetchCompatibleBusinessProfile` (profile.ts) re-fetches the most
+//     recent in-range rendering before we get here. The `profile` passed
+//     in is already the rendering we negotiate against.
 //
 //   • Endpoint validation. `services[cap][n]` already passed
 //     `businessProfileSchema`, which rejects mcp/rest entries without
@@ -363,9 +374,4 @@ export function negotiateService(options: NegotiateOptions): NegotiatedService {
     transport: candidate.transport,
     entry: candidate,
   }
-}
-
-function isVersionInRange(version: string | undefined, range: AgentRange): boolean {
-  if (version === undefined) return false
-  return version >= range.min && version <= range.max
 }

--- a/src/core/profile.ts
+++ b/src/core/profile.ts
@@ -11,7 +11,7 @@
 
 import { join } from 'node:path'
 
-import type { z } from 'incur'
+import { z } from 'incur'
 
 import { ErrorCodes, UcpError } from '../lib/errors.js'
 import { omitUndefined } from '../lib/omit-undefined.js'
@@ -19,7 +19,7 @@ import { formatZodIssues } from '../lib/zod-format.js'
 import { fetchCached, ucpHomeDir } from './cache.js'
 import { type BusinessProfile, businessProfileSchema } from './generated/business_profile.zod.js'
 import { type PlatformProfile, platformProfileSchema } from './generated/platform_profile.zod.js'
-import { parseHttpsUrl } from './url.js'
+import { acceptsHttpsUrl, parseHttpsUrl } from './url.js'
 
 export type { BusinessProfile, PlatformProfile }
 
@@ -194,23 +194,27 @@ function defaultBusinessCacheDir(): string {
   return join(ucpHomeDir(), 'cache', 'businesses')
 }
 
+const PROFILE_ERROR_CODES = {
+  fetchFailed: ErrorCodes.PROFILE_FETCH_FAILED,
+  invalidJson: ErrorCodes.PROFILE_INVALID_JSON,
+  schemaInvalid: ErrorCodes.PROFILE_SCHEMA_INVALID,
+} as const
+
 /**
- * Fetch a business profile from `<businessUrl>/.well-known/ucp`.
+ * Fetch and validate a business profile from an explicit document URL: the
+ * canonical `<origin>/.well-known/ucp`, or a version-specific document linked
+ * from `supported_versions`. Callers pick `cacheDir`; `fetchCached` names the
+ * file after the URL's origin, so documents that share an origin need
+ * distinct directories.
  */
-export async function fetchBusinessProfile(
-  businessUrl: string,
+export async function fetchBusinessProfileFromUrl(
+  profileUrl: string,
   options: FetchProfileOptions = {},
 ): Promise<BusinessProfile> {
-  const baseUrl = parseHttpsUrl(businessUrl, 'business URL')
-  const wellKnownUrl = new URL('/.well-known/ucp', baseUrl).toString()
-  return fetchCached<BusinessProfile>(wellKnownUrl, {
+  return fetchCached<BusinessProfile>(profileUrl, {
     cacheDir: options.cacheDir ?? defaultBusinessCacheDir(),
     schema: businessProfileSchema,
-    errorCodes: {
-      fetchFailed: ErrorCodes.PROFILE_FETCH_FAILED,
-      invalidJson: ErrorCodes.PROFILE_INVALID_JSON,
-      schemaInvalid: ErrorCodes.PROFILE_SCHEMA_INVALID,
-    },
+    errorCodes: PROFILE_ERROR_CODES,
     errorLayer: 'transport',
     ...omitUndefined({
       force: options.force,
@@ -219,4 +223,160 @@ export async function fetchBusinessProfile(
       headers: options.headers,
     }),
   })
+}
+
+/**
+ * Fetch a business profile from `<businessUrl>/.well-known/ucp`.
+ */
+export async function fetchBusinessProfile(
+  businessUrl: string,
+  options: FetchProfileOptions = {},
+): Promise<BusinessProfile> {
+  const baseUrl = parseHttpsUrl(businessUrl, 'business URL')
+  return fetchBusinessProfileFromUrl(new URL('/.well-known/ucp', baseUrl).toString(), options)
+}
+
+/**
+ * The only two fields version selection needs from `/.well-known/ucp`. The
+ * top-level document is parsed against this, not the full profile schema,
+ * so a future spec release can reshape the profile without also blocking
+ * the `supported_versions` fallback that exists to survive exactly that.
+ * Every field is preserved (catchall) for the full validation that follows
+ * once a rendering is selected.
+ */
+const profileEnvelopeSchema = z
+  .object({
+    ucp: z
+      .object({
+        version: z.string(),
+        supported_versions: z.record(z.string(), z.string()).optional(),
+      })
+      .catchall(z.unknown()),
+  })
+  .catchall(z.unknown())
+
+/** `min <= version <= max`. ISO `YYYY-MM-DD` strings compare lexicographically. */
+export function isVersionInRange(version: string | undefined, range: AgentRange): boolean {
+  if (version === undefined) return false
+  return version >= range.min && version <= range.max
+}
+
+export interface ResolveProfileOptions extends FetchProfileOptions {
+  /** Defaults to `AGENT_PROTOCOL_RANGE` (build-time). */
+  agentRange?: AgentRange
+}
+
+export interface ResolvedBusinessProfile {
+  profile: BusinessProfile
+  /** URL of the document `profile` was parsed from. */
+  profileUrl: string
+  /** `profile.ucp.version`; equals the `supported_versions` key when a fallback was taken. */
+  version: string
+  /** True when `profile` came from `supported_versions`, not `/.well-known/ucp`. */
+  fromSupportedVersions: boolean
+}
+
+/**
+ * Fetch the business profile rendering this agent can negotiate against,
+ * per the spec's "Protocol Version" rules:
+ *
+ *   1. Fetch `/.well-known/ucp`. If its `ucp.version` is inside `agentRange`,
+ *      that document is the profile.
+ *   2. Otherwise pick the most recent `supported_versions` key inside the
+ *      range and fetch the linked document. Its `ucp.version` MUST equal the
+ *      key, else the platform MUST NOT use it. Version-specific documents are
+ *      leaves: their own `supported_versions` (if any) is not followed.
+ *   3. If neither yields a version in range, PROTOCOL_VERSION_INCOMPATIBLE.
+ *
+ * Version selection deliberately precedes transport negotiation: a top-level
+ * document whose version is in range is used even if a lower-version rendering
+ * would have offered a nicer transport mix. That is the spec's ordering, and
+ * keeps "what did we negotiate against" a function of version alone.
+ *
+ * Cache layout: the top-level document lives at `<cacheDir>/<origin>.json`;
+ * a version-specific document lives at `<cacheDir>/<version>/<origin>.json`
+ * (origin of the linked URL, which may differ from the business origin).
+ */
+export async function fetchCompatibleBusinessProfile(
+  businessUrl: string,
+  options: ResolveProfileOptions = {},
+): Promise<ResolvedBusinessProfile> {
+  const { agentRange = AGENT_PROTOCOL_RANGE, ...fetchOptions } = options
+  const cacheDir = fetchOptions.cacheDir ?? defaultBusinessCacheDir()
+  const baseUrl = parseHttpsUrl(businessUrl, 'business URL')
+  const wellKnownUrl = new URL('/.well-known/ucp', baseUrl).toString()
+
+  const top = await fetchCached(wellKnownUrl, {
+    cacheDir,
+    schema: profileEnvelopeSchema,
+    errorCodes: PROFILE_ERROR_CODES,
+    errorLayer: 'transport',
+    ...omitUndefined({
+      force: fetchOptions.force,
+      fetch: fetchOptions.fetch,
+      signal: fetchOptions.signal,
+      headers: fetchOptions.headers,
+    }),
+  })
+  if (isVersionInRange(top.ucp.version, agentRange)) {
+    const result = businessProfileSchema.safeParse(top)
+    if (!result.success) {
+      throw new UcpError({
+        layer: 'transport',
+        code: ErrorCodes.PROFILE_SCHEMA_INVALID,
+        message: `response failed schema validation at ${wellKnownUrl}: ${formatZodIssues(result.error.issues)}`,
+      })
+    }
+    return {
+      profile: result.data,
+      profileUrl: wellKnownUrl,
+      version: top.ucp.version,
+      fromSupportedVersions: false,
+    }
+  }
+
+  const supported = top.ucp.supported_versions
+  const offered = Object.keys(supported ?? {}).sort()
+  const candidate = offered
+    .filter((v) => v !== top.ucp.version && isVersionInRange(v, agentRange))
+    .sort()
+    .at(-1)
+  if (candidate === undefined || supported === undefined) {
+    throw new UcpError({
+      layer: 'transport',
+      code: ErrorCodes.PROTOCOL_VERSION_INCOMPATIBLE,
+      message: `business profile is UCP ${top.ucp.version}, outside agent range [${agentRange.min}..${agentRange.max}]; supported_versions offers ${offered.length > 0 ? offered.join(', ') : 'none'}`,
+      context: { agentRange, version: top.ucp.version, supportedVersions: offered },
+    })
+  }
+
+  const versionedUrl = supported[candidate] as string
+  if (!acceptsHttpsUrl(versionedUrl)) {
+    throw new UcpError({
+      layer: 'transport',
+      code: ErrorCodes.PROFILE_SCHEMA_INVALID,
+      message: `business profile supported_versions["${candidate}"] is not an https URL: ${versionedUrl}`,
+      context: { version: candidate, url: versionedUrl },
+    })
+  }
+
+  const leaf = await fetchBusinessProfileFromUrl(versionedUrl, {
+    ...fetchOptions,
+    cacheDir: join(cacheDir, candidate),
+  })
+  if (leaf.ucp.version !== candidate) {
+    throw new UcpError({
+      layer: 'transport',
+      code: ErrorCodes.PROFILE_VERSION_MISMATCH,
+      message: `business profile at ${versionedUrl} declares UCP ${leaf.ucp.version} but was linked as supported_versions["${candidate}"]`,
+      context: { expected: candidate, actual: leaf.ucp.version, url: versionedUrl },
+    })
+  }
+
+  return {
+    profile: leaf,
+    profileUrl: versionedUrl,
+    version: candidate,
+    fromSupportedVersions: true,
+  }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -42,8 +42,18 @@ export const ErrorCodes = {
   PROFILE_INVALID_JSON: 'PROFILE_INVALID_JSON',
   /** Business profile body parsed as JSON but failed schema validation. */
   PROFILE_SCHEMA_INVALID: 'PROFILE_SCHEMA_INVALID',
-  /** Business + CLI protocol ranges don't intersect. */
+  /**
+   * Business + CLI protocol ranges don't intersect: neither the top-level
+   * profile's `ucp.version` nor any `supported_versions` key is in range, or
+   * the selected rendering has no service entry in range.
+   */
   PROTOCOL_VERSION_INCOMPATIBLE: 'PROTOCOL_VERSION_INCOMPATIBLE',
+  /**
+   * A `supported_versions` document declares a different `ucp.version` than
+   * the key that linked to it. The spec says the platform MUST NOT use such a
+   * document, so discovery stops here instead of negotiating against it.
+   */
+  PROFILE_VERSION_MISMATCH: 'PROFILE_VERSION_MISMATCH',
   /** Business profile parses cleanly but does not advertise the requested capability. */
   CAPABILITY_NOT_OFFERED: 'CAPABILITY_NOT_OFFERED',
   /** Business negotiated a capability but did not expose the requested operation/tool. */


### PR DESCRIPTION
## Summary

Follow-on to #50. Every UCP release Shopify ships ahead of the CLI's pinned `protocolMax` is currently a hard outage (`PROTOCOL_VERSION_INCOMPATIBLE` or `NO_COMPATIBLE_TRANSPORT`, see #48), because discovery only ever reads the top-level `/.well-known/ucp` rendering.

This implements the spec's "Protocol Version" fallback. When the top-level document is rendered at a version outside `[protocolMin, protocolMax]`, discovery:

1. picks the most recent in-range key from `ucp.supported_versions`,
2. fetches that document,
3. verifies its `ucp.version` equals the key (the spec says a mismatching document MUST NOT be used), and
4. negotiates transports against it.

Version-specific documents are treated as leaves; their own `supported_versions` is not followed.

Based on `main` and independent of #50: the tests derive the in-range leaf version from the test's own range constant, so they pass on either side of the bump.

## Changes

- `profile.ts`: `fetchBusinessProfileFromUrl` and `fetchCompatibleBusinessProfile`; `isVersionInRange` moves here from `discover.ts`.
- The top-level document is parsed against a two-field envelope (`ucp.version`, `ucp.supported_versions`) before version selection, and against the full profile schema only once selected. A future release that reshapes the profile cannot block the fallback that exists to survive it.
- Versioned documents cache under `<cache>/businesses/<version>/<origin>.json` so they never collide with the top-level file for the same origin.
- New `PROFILE_VERSION_MISMATCH` error code, documented in the skill reference. `PROTOCOL_VERSION_INCOMPATIBLE` from this path lists the offered `supported_versions` in its message and context.
- Ten regression tests in `discover.test.ts`, plus a minor changeset.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (623 passing), `pnpm build`.
- Exercised live against Shopify with a simulated range max of 2026-04-08: racing.shop, progressivenutritional.com, and catalog.shopify.com all resolved the 2026-04-08 `supported_versions` document and negotiated mcp with endpoints.

## Not in scope

The CLI still ignores `meta.protocol_versions` on the user profile and negotiates only with the build-time range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)